### PR TITLE
Update interpretinghpbeta example; add ground example

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,7 +27,8 @@ examples = [
     "integratedreflection.jl",
     "wavefieldintegration.jl",
     "magneticfield.jl",
-    "interpretinghpbeta.jl"
+    "interpretinghpbeta.jl",
+    "ground.jl"
 ]
 
 for example in examples
@@ -53,7 +54,8 @@ example_pages = Any[
     "generated/integratedreflection.md",
     "generated/wavefieldintegration.md",
     "generated/magneticfield.md",
-    "generated/interpretinghpbeta.md"
+    "generated/interpretinghpbeta.md",
+    "generated/ground.md"
 ]
 
 library_pages = Any[

--- a/examples/ground.jl
+++ b/examples/ground.jl
@@ -1,0 +1,82 @@
+# # Ground
+# 
+# LongwaveModePropagator treats the ground boundary of the Earth-ionosphere waveguide
+# as a homogeneous, nonmagnetic material described by its electrical conductivity ``\sigma``
+# and relative permittivity ``\epsilon_r``.
+# 
+# In this example we'll compare the effect of ground conductivity on amplitude along
+# the ground in the waveguide for day and nighttime ionospheres.
+
+using Plots, Printf
+using LongwaveModePropagator
+const LMP = LongwaveModePropagator
+
+# LWPC uses standard ground indices to describe combinations of relative permittivity
+# and conductivity.
+# The standard indices can be accessed from LMP as [`GROUND`](@ref).
+
+sort(GROUND)
+
+# We'll define all of the constant types and the day and night profiles.
+
+## Constant values
+const BFIELD = BField(50e-6, π/2, 0)
+
+const TX = Transmitter(20e3)
+const RX = GroundSampler(0:5e3:3000e3, Fields.Ez)
+
+const DAY = Species(LMP.QE, LMP.ME, z->waitprofile(z, 75, 0.3), electroncollisionfrequency)
+const NIGHT = Species(LMP.QE, LMP.ME, z->waitprofile(z, 82, 0.6), electroncollisionfrequency)
+
+# We'll define a function to which we can pass the day or night `Species` and return the
+# electric field amplitude.
+
+function varyground(prf)
+    amps = Vector{Vector{Float64}}(undef, length(GROUND))
+    for i = 1:length(GROUND)
+        wvg = HomogeneousWaveguide(BFIELD, prf, GROUND[i])
+        E, a, p = propagate(wvg, TX, RX)
+        amps[i] = a
+    end
+    return amps
+end
+
+# And here's a function to plot each of the curves.
+
+function buildplots!(p, amps)
+    cmap = palette(:thermal, length(GROUND)+1)  # +1 so we don't get to yellow
+
+    for i = 1:length(GROUND)
+        plot!(p, RX.distance/1000, amps[i],
+              label=@sprintf("%d, %.1g", GROUND[i].ϵᵣ, GROUND[i].σ), color=cmap[i]);
+    end
+end
+
+# First, the daytime results.
+
+amps = varyground(DAY)
+
+p = plot()
+buildplots!(p, amps)
+plot!(p, size=(600,400), ylims=(22, 95), title="Day",
+      xlabel="Range (km)", ylabel="Amplitude (dB)", legendtitle="ϵᵣ, σ")
+#md savefig(p, "ground_day.png"); nothing # hide
+#md # ![](ground_day.png
+
+# And now nighttime.
+
+amps = varyground(NIGHT)
+
+p = plot()
+buildplots!(p, amps)
+plot!(p, size=(600,400), ylims=(22, 95), title="Night",
+      xlabel="Range (km)", ylabel="Amplitude (dB)", legendtitle="ϵᵣ, σ")
+#md savefig(p, "ground_night.png"); nothing # hide
+#md # ![](ground_night.png
+
+# Low ground conductivity can have a significant influence on the signal propagation.
+# These low conductivities can be found in areas of sea or polar ice and industrial or
+# city areas.
+# 
+# The influence of ground conductivity on the received signal is independent of the
+# ionosphere and has equal impact on the day and night scenarios.

--- a/examples/ground.jl
+++ b/examples/ground.jl
@@ -58,7 +58,7 @@ amps = varyground(DAY)
 
 p = plot()
 buildplots!(p, amps)
-plot!(p, size=(600,400), ylims=(22, 95), title="Day",
+plot!(p, size=(600,400), ylims=(0, 95), title="Day", legend=(0.85, 1.02),
       xlabel="Range (km)", ylabel="Amplitude (dB)", legendtitle="ϵᵣ, σ")
 #md savefig(p, "ground_day.png"); nothing # hide
 #md # ![](ground_day.png
@@ -69,14 +69,15 @@ amps = varyground(NIGHT)
 
 p = plot()
 buildplots!(p, amps)
-plot!(p, size=(600,400), ylims=(22, 95), title="Night",
+plot!(p, size=(600,400), ylims=(0, 95), title="Night", legend=(0.85, 1.02),
       xlabel="Range (km)", ylabel="Amplitude (dB)", legendtitle="ϵᵣ, σ")
 #md savefig(p, "ground_night.png"); nothing # hide
 #md # ![](ground_night.png
 
-# Low ground conductivity can have a significant influence on the signal propagation.
+# Low ground conductivity can have a significant influence on the signal propagation -
+# there is strong attenuation.
 # These low conductivities can be found in areas of sea or polar ice and industrial or
 # city areas.
 # 
-# The influence of ground conductivity on the received signal is independent of the
-# ionosphere and has equal impact on the day and night scenarios.
+# The influence of ground conductivity on the received signal has similar impact on
+# the day and night scenarios.

--- a/examples/interpretinghpbeta.jl
+++ b/examples/interpretinghpbeta.jl
@@ -73,7 +73,7 @@ bfield = BField(50e-6, π/2, 0)
 ground = GROUND[5]
 
 tx = Transmitter(20e3)
-rx = GroundSampler(0:5e3:2000e3, Fields.Ez)
+rx = GroundSampler(0:5e3:3000e3, Fields.Ez)
 nothing  #hide
 
 # ## Varying h′
@@ -145,8 +145,12 @@ plot!(p, size=(600,400), ylims=(22, 95),
 #md savefig(p, "interpreting_betas.png"); nothing # hide
 #md # ![](interpreting_betas.png)
 
-# Broadly, the signal increases with increasing β.
-# Morfitt (1977) also suggests that an increase in β leads to the signal levels varying
+# The signal roughly increases with increasing β.
+# Higher β profiles more closely represent a sharp reflecting boundary.
+# 
+# It may be more accurate to say that higher β ionospheres lead to more extreme amplitudes -
+# higher highs and lower lows.
+# Morfitt (1977) describes this as an increase in β leads to the signal levels varying
 # over a wider range in the regions of strong modal interference.
 
 # ## Varying frequency

--- a/examples/magneticfield.jl
+++ b/examples/magneticfield.jl
@@ -1,7 +1,7 @@
 # # Magnetic field direction
 #
 # In this example we'll look at the influence of the magnetic field direction on
-# a nighttime ionosphere propagation path.
+# a nighttime and daytime ionosphere propagation path.
 # Results will be compared to LWPC.
 #
 # ## Generate scenarios
@@ -36,7 +36,7 @@ nothing  #hide
 # to also write the `BatchInput` to a file.
 # That's not necessary here.
 
-function generate()
+function generate(hp, β)
     batch = BatchInput{BasicInput}()
     batch.name = "Magnetic field tests"
     batch.description = "Varying magnetic field directions: vertical, N, E, S, W."
@@ -46,8 +46,8 @@ function generate()
     frequency = 24e3
     output_ranges = collect(OUTPUT_RANGES)
     segment_ranges = [0.0]
-    hprime = [82.0]
-    beta = [0.6]
+    hprime = [hp]
+    beta = [β]
 
     ## Ocean
     ground_epsr = [81]
@@ -89,7 +89,7 @@ function generate()
     return batch
 end
 
-batch = generate();
+batch = generate(82.0, 0.6);
 
 # ## Run the model
 #
@@ -235,3 +235,23 @@ plot(OUTPUT_RANGES/1000, adifference,
 # The 315°/225° line has the worst match, although it is not clear if there is
 # a particular cause for this outside of the general differences between the
 # two models.
+
+# ## Daytime ionosphere
+# 
+# Does magnetic field direction have a different level of influence with daytime ionospheres?
+
+lmpfile = joinpath(examples_dir, "bfields_daytime_lmp.h5")
+runlmp(generate(72.0, 0.3), lmpfile)
+
+agrid, pgrid = h5open(lmpfile, "r") do o
+    agrid, pgrid = process(o)
+end
+
+plot(OUTPUT_RANGES/1000, agrid,
+     linewidth=1.5, palette=colors, colorbar=false,
+     xlabel="range (km)", ylabel="amplitude (dB)",
+     labels=permutedims(labels), legendtitle="  dip, az", legend=true)
+#md savefig("magneticfield_daytime_amplitude.png"); nothing # hide
+#md # ![](magneticfield_daytime_amplitude.png)
+
+# At these lower reflection altitudes the effect of Earth's magnetic field is decreased. 


### PR DESCRIPTION
- Extend receiver range to 3000 km
- Draw reflection height (where `\omega_r = \omega`) on collision frequency profile plots

These changes more clearly show the influence of each of the parameters being explored in the example.