### PR TITLE
Use semicolons to separate keyword arguments

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -248,9 +248,9 @@ version = "1.2.0"
 
 [[JSON3]]
 deps = ["Dates", "Mmap", "Parsers", "StructTypes", "UUIDs"]
-git-tree-sha1 = "7fb482aece0faf6529f2e796d60fdeb2ddd117a6"
+git-tree-sha1 = "62d4063c67d7c84d5788107878bb925ceaadd252"
 uuid = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
-version = "1.7.0"
+version = "1.7.1"
 
 [[LabelledArrays]]
 deps = ["ArrayInterface", "LinearAlgebra", "MacroTools", "StaticArrays"]

--- a/examples/basic.jl
+++ b/examples/basic.jl
@@ -307,7 +307,7 @@ E, a, p = propagate(waveguide, tx, rx);
 
 # Here are quick plots of the amplitude
 
-plot(ranges/1000, a,
+plot(ranges/1000, a;
      xlabel="range (km)", ylabel="amplitude (dB)",
      linewidth=1.5, legend=false)
 #md savefig("basic_homogeneousamplitude.png"); nothing # hide
@@ -315,7 +315,7 @@ plot(ranges/1000, a,
 
 # and phase.
 
-plot(ranges/1000, rad2deg.(p),
+plot(ranges/1000, rad2deg.(p);
      xlabel="range (km)", ylabel="phase (deg)",
      linewidth=1.5, legend=false)
 #md savefig("basic_homogeneousphase.png"); nothing # hide
@@ -351,7 +351,7 @@ E, a, p = propagate(waveguide, tx, rx);
 
 # Here are quick plots of the amplitude
 
-plot(ranges/1000, a,
+plot(ranges/1000, a;
      xlabel="range (km)", ylabel="amplitude (dB)",
      linewidth=1.5, legend=false)
 #md savefig("basic_segmentedamplitude.png"); nothing # hide
@@ -359,7 +359,7 @@ plot(ranges/1000, a,
 
 # and phase.
 
-plot(ranges/1000, rad2deg.(p),
+plot(ranges/1000, rad2deg.(p);
      xlabel="range (km)", ylabel="phase (deg)",
      linewidth=1.5, legend=false)
 #md savefig("basic_segmentedphase.png"); nothing # hide

--- a/examples/ground.jl
+++ b/examples/ground.jl
@@ -47,7 +47,7 @@ function buildplots!(p, amps)
     cmap = palette(:thermal, length(GROUND)+1)  # +1 so we don't get to yellow
 
     for i = 1:length(GROUND)
-        plot!(p, RX.distance/1000, amps[i],
+        plot!(p, RX.distance/1000, amps[i];
               label=@sprintf("%d, %.1g", GROUND[i].ϵᵣ, GROUND[i].σ), color=cmap[i]);
     end
 end
@@ -58,7 +58,7 @@ amps = varyground(DAY)
 
 p = plot()
 buildplots!(p, amps)
-plot!(p, size=(600,400), ylims=(0, 95), title="Day", legend=(0.85, 1.02),
+plot!(p; size=(600,400), ylims=(0, 95), title="Day", legend=(0.85, 1.02),
       xlabel="Range (km)", ylabel="Amplitude (dB)", legendtitle="ϵᵣ, σ")
 #md savefig(p, "ground_day.png"); nothing # hide
 #md # ![](ground_day.png
@@ -69,7 +69,7 @@ amps = varyground(NIGHT)
 
 p = plot()
 buildplots!(p, amps)
-plot!(p, size=(600,400), ylims=(0, 95), title="Night", legend=(0.85, 1.02),
+plot!(p; size=(600,400), ylims=(0, 95), title="Night", legend=(0.85, 1.02),
       xlabel="Range (km)", ylabel="Amplitude (dB)", legendtitle="ϵᵣ, σ")
 #md savefig(p, "ground_night.png"); nothing # hide
 #md # ![](ground_night.png

--- a/examples/integratedreflection.jl
+++ b/examples/integratedreflection.jl
@@ -87,7 +87,7 @@ me = PhysicalModeEquation(ea, frequency, waveguide);
 
 prob = ODEProblem{false}(LMP.dRdz, Rtop, (topheight, 0.0), (me, LMPParams()))
 
-sol = solve(prob, RK4(), abstol=1e-9, reltol=1e-9);
+sol = solve(prob, RK4(); abstol=1e-9, reltol=1e-9);
 
 # Let's plot the reflection coefficients next to the electron density and collision
 # frequency curves.
@@ -105,31 +105,31 @@ eqz = altinterp(frequency.ω)  # altitude where ω = ωᵣ
 ne[end] = NaN  # otherwise Plots errors
 Wr[end] = NaN
 
-p1 = plot([ne nu Wr], zs/1000,
+p1 = plot([ne nu Wr], zs/1000;
           xlims=(10, 10^10), xaxis=(scale=:log10),
           ylabel="Altitude (km)",
           labels=["Nₑ (m⁻³)" "ν (s⁻¹)" "ωᵣ = ωₚ²/ν"], legend=:topleft,
           linewidth=1.5);
 
-vline!(p1, [frequency.ω], linestyle=:dash, color="gray", label="");
-hline!(p1, [eqz/1000], linestyle=:dash, color="gray", label="");
+vline!(p1, [frequency.ω]; linestyle=:dash, color="gray", label="");
+hline!(p1, [eqz/1000]; linestyle=:dash, color="gray", label="");
 annotate!(p1, frequency.ω, 10, text(" ω", :left, 9));
 annotate!(p1, 70, eqz/1000-3, text("ωᵣ = ω", :left, 9));
 
-R11 = abs.(sol(zs, idxs=1))
-R21 = abs.(sol(zs, idxs=2))
-R12 = abs.(sol(zs, idxs=3))
-R22 = abs.(sol(zs, idxs=4))
+R11 = abs.(sol(zs; idxs=1))
+R21 = abs.(sol(zs; idxs=2))
+R12 = abs.(sol(zs; idxs=3))
+R22 = abs.(sol(zs; idxs=4))
 
-p2 = plot([R11 R21 R12 R22], zs/1000,
+p2 = plot([R11 R21 R12 R22], zs/1000;
           xlims=(0, 1),
           yaxis=false, yformatter=_->"",
           legend=:right, labels=["R₁₁" "R₂₁" "R₁₂" "R₂₂"],
           linewidth=1.5);
 
-hline!(p2, [eqz/1000], linestyle=:dash, color="gray", label="");
+hline!(p2, [eqz/1000]; linestyle=:dash, color="gray", label="");
 
-plot(p1, p2, layout=(1,2), size=(800, 400))
+plot(p1, p2; layout=(1,2), size=(800, 400))
 #md savefig("integratedreflection_xyz.png"); nothing # hide
 #md # ![](integratedreflection_xyz.png)
 
@@ -182,7 +182,7 @@ scenarios = generatescenarios(30);
 ip = IntegrationParams(tolerance=1e-14, solver=RK4(), maxiters=1_000_000)
 params = LMPParams(integrationparams=ip)
 
-Rrefs = [LMP.integratedreflection(scenario, params=params) for scenario in scenarios];
+Rrefs = [LMP.integratedreflection(scenario; params=params) for scenario in scenarios];
 
 # ## Evaluate solvers
 #
@@ -203,13 +203,13 @@ function compute(scenarios, tolerances, solvers)
 
             for i in eachindex(scenarios)
                 ## warmup
-                R = LMP.integratedreflection(scenarios[i], params=params)
+                R = LMP.integratedreflection(scenarios[i]; params=params)
 
                 ## loop for average time
                 N = 25
                 t0 = time_ns()
                 for n = 1:N
-                    R = LMP.integratedreflection(scenarios[i], params=params)
+                    R = LMP.integratedreflection(scenarios[i]; params=params)
                 end
                 ttotal = time_ns() - t0
 
@@ -244,9 +244,9 @@ function differr(a, ref)
 end
 
 Rerrs = differr(Rs, Rrefs)
-mean_Rerrs = dropdims(mean(Rerrs, dims=1), dims=1)
+mean_Rerrs = dropdims(mean(Rerrs; dims=1); dims=1)
 
-heatmap(tolerancestrings, solverstrings, permutedims(log10.(mean_Rerrs)),
+heatmap(tolerancestrings, solverstrings, permutedims(log10.(mean_Rerrs));
         clims=(-8, -3),
         xlabel="tolerance", ylabel="solver",
         colorbar_title="log₁₀ max abs difference", colorbar=true)
@@ -255,9 +255,9 @@ heatmap(tolerancestrings, solverstrings, permutedims(log10.(mean_Rerrs)),
 
 # And the average runtimes are
 
-mean_times = dropdims(mean(times, dims=1), dims=1)
+mean_times = dropdims(mean(times; dims=1); dims=1)
 
-heatmap(tolerancestrings, solverstrings, permutedims(mean_times)/1e6,
+heatmap(tolerancestrings, solverstrings, permutedims(mean_times)/1e6;
         clims=(0, 9),
         xlabel="tolerance", ylabel="solver",
         colorbar_title="time (μs)", colorbar=true)

--- a/examples/interpretinghpbeta.jl
+++ b/examples/interpretinghpbeta.jl
@@ -99,12 +99,12 @@ function buildplots!(p, amps)
     cmap = palette(:amp, length(hprimes)+1) # +1 allows us to use a darker lightest color
 
     for i in eachindex(hprimes)
-        plot!(p, RX.distance/1000, amps[i],
+        plot!(p, RX.distance/1000, amps[i];
               label=hprimes[i], color=cmap[i+1]);
     end
 end
 buildplots!(p, amps);
-plot!(p, size=(600,400), ylims=(22, 95),
+plot!(p; size=(600,400), ylims=(22, 95),
       xlabel="Range (km)", ylabel="Amplitude (dB)", legendtitle="h′")
 #md savefig(p, "interpreting_hprimes.png"); nothing # hide
 #md # ![](interpreting_hprimes.png)
@@ -135,12 +135,12 @@ function buildplots!(p, amps)
     cmap = palette(:amp, length(betas)+1)
 
     for i in eachindex(betas)
-        plot!(p, RX.distance/1000, amps[i],
+        plot!(p, RX.distance/1000, amps[i];
               label=betas[i], color=cmap[i+1]);
     end
 end
 buildplots!(p, amps);
-plot!(p, size=(600,400), ylims=(22, 95),
+plot!(p; size=(600,400), ylims=(22, 95),
       xlabel="Range (km)", ylabel="Amplitude (dB)", legendtitle="β")
 #md savefig(p, "interpreting_betas.png"); nothing # hide
 #md # ![](interpreting_betas.png)
@@ -177,18 +177,18 @@ amps = varyfreq(freqs)
 p = plot();
 function buildplots!(p, amps)
     pal = palette(:rainbow, 7)
-    cmap = [pal[1]; range(pal[2], pal[3], length=2); range(pal[4], pal[5], length=4);
-            range(pal[6], pal[7], length=3)]
+    cmap = [pal[1]; range(pal[2], pal[3]; length=2); range(pal[4], pal[5]; length=4);
+            range(pal[6], pal[7]; length=3)]
 
     for i in eachindex(freqs)
         fkHz = trunc(Int, freqs[i]/1000)
-        λkm = trunc(LMP.C0/freqs[i]/1000, digits=1)
-        plot!(p, RX.distance/1000, amps[i] .+ (10*i),
+        λkm = trunc(LMP.C0/freqs[i]/1000; digits=1)
+        plot!(p, RX.distance/1000, amps[i] .+ (10*i);
               label=string(fkHz, ",  ", λkm), color=cmap[i]);
     end
 end
 buildplots!(p, amps);
-plot!(p, size=(600,400),
+plot!(p; size=(600,400),
       xlabel="Range (km)", ylabel="Amplitude (dB)", legendtitle="f kHz, λ km")
 #md savefig(p, "interpreting_frequencies.png"); nothing # hide
 #md # ![](interpreting_frequencies.png)
@@ -232,14 +232,14 @@ function buildplots!(p, params, hp, β)
         eqz = reflectionheight(params[i], hp, β)
 
         v₀label = params[i][1]/1.816
-        plot!(p, collisionfrequency.(alt, params[i]...), alt/1000,
+        plot!(p, collisionfrequency.(alt, params[i]...), alt/1000;
               label=@sprintf("%.0e, %.2f", v₀label, params[i][2]), color=cmap[i]);
-        hline!(p, [eqz/1000], linestyle=:dash, color=cmap[i], linewidth=0.6, label=nothing)
+        hline!(p, [eqz/1000]; linestyle=:dash, color=cmap[i], linewidth=0.6, label=nothing)
     end
 end
 buildplots!(p, params, 75, 0.35);
 annotate!(p, [(1e3, 64, text("ωᵣ = ω", 10))])
-plot!(p, size=(600,400), xscale=:log10,
+plot!(p; size=(600,400), xscale=:log10,
       xlabel="ν (s⁻¹)", ylabel="Altitude (km)", legendtitle="1.816 ν₀, a")
 #md savefig(p, "interpreting_collisionprofile.png"); nothing # hide
 #md # ![](interpreting_collisionprofile.png)
@@ -265,12 +265,12 @@ function buildplots!(p, amps)
 
     for i in eachindex(params)
         v₀label = params[i][1]/1.816
-        plot!(p, RX.distance/1000, amps[i],
+        plot!(p, RX.distance/1000, amps[i];
               label=@sprintf("%.0e, %.2f", v₀label, params[i][2]), color=cmap[i]);
     end
 end
 buildplots!(p, amps);
-plot!(p, size=(600,400), ylims=(22, 95),
+plot!(p; size=(600,400), ylims=(22, 95),
       xlabel="Range (km)", ylabel="Amplitude (dB)", legendtitle="1.816 ν₀, a")
 #md savefig(p, "interpreting_collisionday.png"); nothing # hide
 #md # ![](interpreting_collisionday.png)
@@ -285,12 +285,12 @@ function buildplots!(p, amps)
 
     for i in eachindex(params)
         v₀label = params[i][1]/1.816
-        plot!(p, RX.distance/1000, amps[i],
+        plot!(p, RX.distance/1000, amps[i];
               label=@sprintf("%.0e, %.2f", v₀label, params[i][2]), color=cmap[i]);
     end
 end
 buildplots!(p, amps);
-plot!(p, size=(600,400), ylims=(22, 95),
+plot!(p; size=(600,400), ylims=(22, 95),
       xlabel="Range (km)", ylabel="Amplitude (dB)", legendtitle="1.816 ν₀, a")
 #md savefig(p, "interpreting_collisionnight.png"); nothing # hide
 #md # ![](interpreting_collisionnight.png)

--- a/examples/magneticfield.jl
+++ b/examples/magneticfield.jl
@@ -195,7 +195,7 @@ labels[3:end] .= "      ".*labels[3:end]
 colors = [palette(:phase, length(B_AZS))...]
 pushfirst!(colors, RGB(0.0, 0, 0))
 
-plot(OUTPUT_RANGES/1000, agrid,
+plot(OUTPUT_RANGES/1000, agrid;
      linewidth=1.5, palette=colors, colorbar=false,
      xlabel="range (km)", ylabel="amplitude (dB)",
      labels=permutedims(labels), legendtitle="  dip, az", legend=true)
@@ -222,7 +222,7 @@ end
 
 adifference = agrid - lagrid
 
-plot(OUTPUT_RANGES/1000, adifference,
+plot(OUTPUT_RANGES/1000, adifference;
      linewidth=1.5, palette=colors, colorbar=false,
      xlabel="range (km)", ylabel="amplitude difference (dB)",
      labels=permutedims(labels), legendtitle="  dip, az", legend=true)
@@ -247,7 +247,7 @@ agrid, pgrid = h5open(lmpfile, "r") do o
     agrid, pgrid = process(o)
 end
 
-plot(OUTPUT_RANGES/1000, agrid,
+plot(OUTPUT_RANGES/1000, agrid;
      linewidth=1.5, palette=colors, colorbar=false,
      xlabel="range (km)", ylabel="amplitude (dB)",
      labels=permutedims(labels), legendtitle="  dip, az", legend=true)

--- a/examples/meshgrid.jl
+++ b/examples/meshgrid.jl
@@ -111,7 +111,7 @@ phase = modeequationphase(day_mid_me, mesh);
 # complex plane, all meet.
 # Each of these locations are either a root or pole in the daytime ionosphere.
 
-heatmap(x, y, reshape(phase, length(x), length(y))',
+heatmap(x, y, reshape(phase, length(x), length(y))';
         color=:twilight, clims=(-180, 180),
         xlims=(0, 90), ylims=(-40, 0),
         xlabel="real(θ)", ylabel="imag(θ)",
@@ -122,7 +122,7 @@ heatmap(x, y, reshape(phase, length(x), length(y))',
 
 # We can zoom in to the upper right corner of the plot to see the lowest order modes:
 
-heatmap(x, y, reshape(phase, length(x), length(y))',
+heatmap(x, y, reshape(phase, length(x), length(y))';
         color=:twilight, clims=(-180, 180),
         xlims=(30, 90), ylims=(-10, 0),
         xlabel="real(θ)", ylabel="imag(θ)",
@@ -137,7 +137,7 @@ heatmap(x, y, reshape(phase, length(x), length(y))',
 
 phase = modeequationphase(night_mid_me, mesh);
 
-heatmap(x, y, reshape(phase, length(x), length(y))',
+heatmap(x, y, reshape(phase, length(x), length(y))';
         color=:twilight, clims=(-180, 180),
         xlims=(0, 90), ylims=(-40, 0),
         xlabel="real(θ)", ylabel="imag(θ)",
@@ -150,7 +150,7 @@ heatmap(x, y, reshape(phase, length(x), length(y))',
 
 phase = modeequationphase(day_low_me, mesh);
 
-heatmap(x, y, reshape(phase, length(x), length(y))',
+heatmap(x, y, reshape(phase, length(x), length(y))';
         color=:twilight, clims=(-180, 180),
         xlims=(0, 90), ylims=(-40, 0),
         xlabel="real(θ)", ylabel="imag(θ)",
@@ -186,12 +186,12 @@ mesh = trianglemesh(zbl, ztr, Δr);
 
 meshdeg = rad2deg.(mesh)
 
-img = plot(real(meshdeg), imag(meshdeg), seriestype=:scatter,
+img = plot(real(meshdeg), imag(meshdeg); seriestype=:scatter,
            xlims=(80, 90), ylims=(-10, 0),
            xlabel="real(θ)", ylabel="imag(θ)",
            legend=false, size=(450,375));
-plot!(img, [80, 90], [0, 0], color="red");
-plot!(img, [0, 90], [-90, 0], color="red")
+plot!(img, [80, 90], [0, 0]; color="red");
+plot!(img, [0, 90], [-90, 0]; color="red")
 #md savefig(img, "meshgrid_trianglemesh.png"); nothing # hide
 #md # ![](meshgrid_trianglemesh.png)
 
@@ -230,13 +230,13 @@ twilightquads = [
     RGB(0.0, 0.0, 0.0)
 ]
 
-img = plot(real(zdeg), imag(zdeg), group=edgecolors, palette=twilightquads, linewidth=1.5,
+img = plot(real(zdeg), imag(zdeg); group=edgecolors, palette=twilightquads, linewidth=1.5,
            xlims=(30, 90), ylims=(-10, 0),
            xlabel="real(θ)", ylabel="imag(θ)", legend=false,
            title=day_mid_title);
-plot!(img, real(rootsdeg), imag(rootsdeg), color="red",
+plot!(img, real(rootsdeg), imag(rootsdeg); color="red",
       seriestype=:scatter, markersize=5);
-plot!(img, real(polesdeg), imag(polesdeg), color="red",
+plot!(img, real(polesdeg), imag(polesdeg); color="red",
       seriestype=:scatter, markershape=:utriangle, markersize=5)
 #md savefig(img, "meshgrid_20kdaymesh.png"); nothing # hide
 #md # ![](meshgrid_20kdaymesh.png)
@@ -256,13 +256,13 @@ rootsdeg = rad2deg.(roots)
 polesdeg = rad2deg.(poles)
 zdeg = rad2deg.(z)
 
-img = plot(real(zdeg), imag(zdeg), group=edgecolors, palette=twilightquads, linewidth=1.5,
+img = plot(real(zdeg), imag(zdeg); group=edgecolors, palette=twilightquads, linewidth=1.5,
            xlims=(30, 90), ylims=(-10, 0),
            xlabel="real(θ)", ylabel="imag(θ)", legend=false,
            title=day_low_title);
-plot!(img, real(rootsdeg), imag(rootsdeg), color="red",
+plot!(img, real(rootsdeg), imag(rootsdeg); color="red",
       seriestype=:scatter, markersize=5);
-plot!(img, real(polesdeg), imag(polesdeg), color="red",
+plot!(img, real(polesdeg), imag(polesdeg); color="red",
       seriestype=:scatter, markershape=:utriangle, markersize=5)
 #md savefig(img, "meshgrid_10kdaymesh.png"); nothing # hide
 #md # ![](meshgrid_10kdaymesh.png)
@@ -279,13 +279,13 @@ rootsdeg = rad2deg.(roots)
 polesdeg = rad2deg.(poles)
 zdeg = rad2deg.(z)
 
-img = plot(real(zdeg), imag(zdeg), group=edgecolors, palette=twilightquads, linewidth=1.5,
+img = plot(real(zdeg), imag(zdeg); group=edgecolors, palette=twilightquads, linewidth=1.5,
            xlims=(30, 90), ylims=(-10, 0),
            xlabel="real(θ)", ylabel="imag(θ)", legend=false,
            title=day_high_title);
-plot!(img, real(rootsdeg), imag(rootsdeg), color="red",
+plot!(img, real(rootsdeg), imag(rootsdeg); color="red",
       seriestype=:scatter, markersize=5);
-plot!(img, real(polesdeg), imag(polesdeg), color="red",
+plot!(img, real(polesdeg), imag(polesdeg); color="red",
       seriestype=:scatter, markershape=:utriangle, markersize=5)
 #md savefig(img, "meshgrid_100kdaymesh.png"); nothing # hide
 #md # ![](meshgrid_100kdaymesh.png)
@@ -300,13 +300,13 @@ rootsdeg = rad2deg.(roots)
 polesdeg = rad2deg.(poles)
 zdeg = rad2deg.(z)
 
-img = plot(real(zdeg), imag(zdeg), group=edgecolors, palette=twilightquads, linewidth=1.5,
+img = plot(real(zdeg), imag(zdeg); group=edgecolors, palette=twilightquads, linewidth=1.5,
            xlims=(30, 90), ylims=(-10, 0),
            xlabel="real(θ)", ylabel="imag(θ)", legend=false,
            title=night_mid_title);
-plot!(img, real(rootsdeg), imag(rootsdeg), color="red",
+plot!(img, real(rootsdeg), imag(rootsdeg); color="red",
       seriestype=:scatter, markersize=5);
-plot!(img, real(polesdeg), imag(polesdeg), color="red",
+plot!(img, real(polesdeg), imag(polesdeg); color="red",
       seriestype=:scatter, markershape=:utriangle, markersize=5)
 #md savefig(img, "meshgrid_20knightmesh.png"); nothing # hide
 #md # ![](meshgrid_20knightmesh.png)

--- a/examples/meshgrid2.jl
+++ b/examples/meshgrid2.jl
@@ -55,7 +55,7 @@ end
 
 phase = modeequationphase(me, mesh);
 
-heatmap(x, y, reshape(phase, length(x), length(y))',
+heatmap(x, y, reshape(phase, length(x), length(y))';
         color=:twilight, clims=(-180, 180),
         xlims=(30, 90), ylims=(-10, 0),
         xlabel="real(θ)", ylabel="imag(θ)",
@@ -91,13 +91,13 @@ twilightquads = [
     RGB(0.0, 0.0, 0.0)
 ]
 
-img = plot(real(zdeg), imag(zdeg), group=edgecolors, palette=twilightquads, linewidth=1.5,
+img = plot(real(zdeg), imag(zdeg); group=edgecolors, palette=twilightquads, linewidth=1.5,
            xlims=(30, 90), ylims=(-10, 0),
            xlabel="real(θ)", ylabel="imag(θ)", legend=false,
            title=title);
-plot!(img, real(rootsdeg), imag(rootsdeg), color="red",
+plot!(img, real(rootsdeg), imag(rootsdeg); color="red",
       seriestype=:scatter, markersize=5);
-plot!(img, real(polesdeg), imag(polesdeg), color="red",
+plot!(img, real(polesdeg), imag(polesdeg); color="red",
       seriestype=:scatter, markershape=:utriangle, markersize=5)
 #md savefig(img, "meshgrid2_20knightmesh.png"); nothing # hide
 #md # ![](meshgrid2_20knightmesh.png)
@@ -130,13 +130,13 @@ zdeg = rad2deg.(z)
 rootsdeg = rad2deg.(roots)
 polesdeg = rad2deg.(poles)
 
-img = plot(real(zdeg), imag(zdeg), group=edgecolors, palette=twilightquads, linewidth=1.5,
+img = plot(real(zdeg), imag(zdeg); group=edgecolors, palette=twilightquads, linewidth=1.5,
            xlims=(30, 90), ylims=(-10, 0),
            xlabel="real(θ)", ylabel="imag(θ)", legend=false,
            title=title);
-plot!(img, real(rootsdeg), imag(rootsdeg), color="red",
+plot!(img, real(rootsdeg), imag(rootsdeg); color="red",
       seriestype=:scatter, markersize=5);
-plot!(img, real(polesdeg), imag(polesdeg), color="red",
+plot!(img, real(polesdeg), imag(polesdeg); color="red",
       seriestype=:scatter, markershape=:utriangle, markersize=5)
 #md savefig(img, "meshgrid2_20knightfinemesh.png"); nothing # hide
 #md # ![](meshgrid2_20knightfinemesh.png)
@@ -145,13 +145,13 @@ plot!(img, real(polesdeg), imag(polesdeg), color="red",
 # Zooming in on the upper right region, we can see that the previously
 # missing roots and poles are very closely spaced.
 
-img = plot(real(zdeg), imag(zdeg), group=edgecolors, palette=twilightquads, linewidth=1.5,
+img = plot(real(zdeg), imag(zdeg); group=edgecolors, palette=twilightquads, linewidth=1.5,
            xlims=(80, 90), ylims=(-2, 0),
            xlabel="real(θ)", ylabel="imag(θ)", legend=false,
            title=title);
-plot!(img, real(rootsdeg), imag(rootsdeg), color="red",
+plot!(img, real(rootsdeg), imag(rootsdeg); color="red",
       seriestype=:scatter, markersize=5);
-plot!(img, real(polesdeg), imag(polesdeg), color="red",
+plot!(img, real(polesdeg), imag(polesdeg); color="red",
       seriestype=:scatter, markershape=:utriangle, markersize=5)
 #md savefig(img, "meshgrid2_20knightfinemeshzoom.png"); nothing # hide
 #md # ![](meshgrid2_20knightfinemeshzoom.png)
@@ -167,10 +167,10 @@ plot!(img, real(polesdeg), imag(polesdeg), color="red",
 mesh = defaultmesh(frequency)
 meshdeg = rad2deg.(mesh)
 
-img = plot(real(meshdeg), imag(meshdeg), seriestype=:scatter,
+img = plot(real(meshdeg), imag(meshdeg); seriestype=:scatter,
            xlabel="real(θ)", ylabel="imag(θ)",
            size=(450,375), legend=false);
-plot!(img, [30, 90], [0, 0], color="red");
-plot!(img, [80, 90], [-10, 0], color="red")
+plot!(img, [30, 90], [0, 0]; color="red");
+plot!(img, [80, 90], [-10, 0]; color="red")
 #md savefig(img, "meshgrid2_defaultmesh.png"); nothing # hide
 #md # ![](meshgrid2_defaultmesh.png)

--- a/examples/wavefieldintegration.jl
+++ b/examples/wavefieldintegration.jl
@@ -126,26 +126,26 @@ nothing  #hide
 zs = 110e3:-50:0
 zskm = zs/1000
 
-e = LMP.integratewavefields(zs, ea, frequency, bfield, day, unscale=true)
-e_unscaled = LMP.integratewavefields(zs, ea, frequency, bfield, day, unscale=false)
+e = LMP.integratewavefields(zs, ea, frequency, bfield, day; unscale=true)
+e_unscaled = LMP.integratewavefields(zs, ea, frequency, bfield, day; unscale=false)
 
 ex1 = getindex.(e, 1)
 ex1_unscaled = getindex.(e_unscaled, 1)
 hx2 = getindex.(e, 7)
 hx2_unscaled = getindex.(e_unscaled, 7)
 
-p1 = plot(real(ex1), zskm, title="\$E_{x,1}\$",
+p1 = plot(real(ex1), zskm; title="\$E_{x,1}\$",
           ylims=(0, 90), xlims=(-1.2, 1.2), linewidth=1.5, ylabel="altitude (km)",
           label="corrected", legend=:topleft);
 plot!(p1, real(ex1_unscaled),
-      zskm, linewidth=1.5, label="scaled only");
+      zskm; linewidth=1.5, label="scaled only");
 
-p2 = plot(real(hx2), zskm, title="\$H_{x,2}\$",
+p2 = plot(real(hx2), zskm; title="\$H_{x,2}\$",
           ylims=(0, 90), xlims=(-1.2, 1.2), linewidth=1.5, legend=false);
 plot!(p2, real(hx2_unscaled),
-      zskm, linewidth=1.5);
+      zskm; linewidth=1.5);
 
-plot(p1, p2, layout=(1,2))
+plot(p1, p2; layout=(1,2))
 #md savefig("wavefields_scaling.png"); nothing # hide
 #md # ![](wavefields_scaling.png)
 
@@ -182,8 +182,8 @@ for s in eachindex(solvers)
     params = LMPParams(wavefieldintegrationparams=ip)
 
     ## make sure method is compiled
-    LMP.integratewavefields(zs, ea, frequency, bfield, day, params=params);
-    LMP.integratewavefields(zs, ea, frequency, bfield, night, params=params);
+    LMP.integratewavefields(zs, ea, frequency, bfield, day; params=params);
+    LMP.integratewavefields(zs, ea, frequency, bfield, night; params=params);
 
     solverstring = solverstrings[s]
     let day_e, night_e
@@ -191,11 +191,11 @@ for s in eachindex(solvers)
         for i = 1:25
             ## day ionosphere
             @timeit TO solverstring begin
-                day_e = LMP.integratewavefields(zs, ea, frequency, bfield, day, params=params)
+                day_e = LMP.integratewavefields(zs, ea, frequency, bfield, day; params=params)
             end
             ## night ionosphere
             @timeit TO solverstring begin
-                night_e = LMP.integratewavefields(zs, ea, frequency, bfield, night, params=params)
+                night_e = LMP.integratewavefields(zs, ea, frequency, bfield, night; params=params)
             end
         end
         push!(day_es, day_e)
@@ -207,7 +207,7 @@ end
 
 day_e1s = [getindex.(e, 1) for e in day_es]
 
-plot(real(day_e1s), zs/1000,
+plot(real(day_e1s), zs/1000;
      label=permutedims(solverstrings), legend=:topleft)
 #md savefig("wavefields_day.png"); nothing # hide
 #md # ![](wavefields_day.png)
@@ -217,7 +217,7 @@ plot(real(day_e1s), zs/1000,
 
 night_e1s = [getindex.(e, 1) for e in night_es]
 
-plot(real(night_e1s), zs/1000,
+plot(real(night_e1s), zs/1000;
      label=permutedims(solverstrings), legend=:topright)
 #md savefig("wavefields_night.png"); nothing # hide
 #md # ![](wavefields_night.png)
@@ -252,7 +252,7 @@ TO
 zs = 110e3:-500:50e3
 zskm = zs/1000
 
-e = LMP.integratewavefields(zs, ea, frequency, bfield, day, unscale=true)
+e = LMP.integratewavefields(zs, ea, frequency, bfield, day; unscale=true)
 
 ex1 = getindex.(e, 1)
 ey1 = getindex.(e, 2)
@@ -260,27 +260,27 @@ ex2 = getindex.(e, 5)
 hx2 = getindex.(e, 7)
 
 function plotfield(field; kwargs...)
-    p = plot(real(field), zskm, color="black", linewidth=1.5, legend=false,
+    p = plot(real(field), zskm; color="black", linewidth=1.5, legend=false,
              xlims=(-0.8, 0.8), label="real",
              framestyle=:grid; kwargs...)
-    plot!(p, imag(field), zskm, color="black",
+    plot!(p, imag(field), zskm; color="black",
           linewidth=1.5, linestyle=:dash, label="imag")
-    plot!(p, abs.(field), zskm, color="black", linewidth=3, label="abs")
-    plot!(p, -abs.(field), zskm, color="black", linewidth=3, label="")
+    plot!(p, abs.(field), zskm; color="black", linewidth=3, label="abs")
+    plot!(p, -abs.(field), zskm; color="black", linewidth=3, label="")
     return p
 end
 
 fs = 10
-ex1p = plotfield(ex1, ylims=(49, 81), yaxis=false, yformatter=_->"");
+ex1p = plotfield(ex1; ylims=(49, 81), yaxis=false, yformatter=_->"");
 annotate!(ex1p, 0.2, 79, text("\$E_{x,1}\$", fs));
-ey1p = plotfield(ey1, ylims=(49, 81));
+ey1p = plotfield(ey1; ylims=(49, 81));
 annotate!(ey1p, 0.2, 79, text("\$E_{y,1}\$", fs));
 annotate!(ey1p, -0.98, 83, text("height (km)", fs));
-ex2p = plotfield(ex2, ylims=(49, 86), yaxis=false, yformatter=_->"");
+ex2p = plotfield(ex2; ylims=(49, 86), yaxis=false, yformatter=_->"");
 annotate!(ex2p, 0.3, 84, text("\$E_{x,2}\$", fs));
-hx2p = plotfield(hx2, ylims=(49, 86));
+hx2p = plotfield(hx2; ylims=(49, 86));
 annotate!(hx2p, 0.35, 84, text("\$H_{x,2}\$", fs, :center));
-plot(ex1p, ey1p, ex2p, hx2p, layout=(2,2), size=(400,600), top_margin=5mm);
+plot(ex1p, ey1p, ex2p, hx2p; layout=(2,2), size=(400,600), top_margin=5mm);
 #md savefig("wavefields_fig2.png"); nothing # hide
 #md # ![](wavefields_fig2.png)
 
@@ -316,9 +316,9 @@ e = LMP.integratewavefields(zs, ea, frequency, bfield, night)
 ey1 = getindex.(e, 2)
 hx2 = getindex.(e, 7)
 
-ey1p = plotfield(ey1, ylims=(75, 102), title="\$E_{y,1}\$");
-hx2p = plotfield(hx2, ylims=(75, 102), title="\$H_{x,2}\$");
-plot(ey1p, hx2p, layout=(1,2), size=(400,500))
+ey1p = plotfield(ey1; ylims=(75, 102), title="\$E_{y,1}\$");
+hx2p = plotfield(hx2; ylims=(75, 102), title="\$H_{x,2}\$");
+plot(ey1p, hx2p; layout=(1,2), size=(400,500))
 #md savefig("wavefields_fig3.png"); nothing # hide
 #md # ![](wavefields_fig3.png)
 # 

--- a/src/LongwaveModePropagator.jl
+++ b/src/LongwaveModePropagator.jl
@@ -115,7 +115,7 @@ p3 = LMPParams(p2; grpf_params=GRPFParams(100000, 1e-6, true))
     curvatureheight::Float64 = 50e3  # m
     grpfparams::GRPFParams = DEFAULT_GRPFPARAMS
     integrationparams::IntegrationParams{T} = IntegrationParams()
-    wavefieldheights::H = range(topheight, 0, length=513)
+    wavefieldheights::H = range(topheight, 0; length=513)
     wavefieldintegrationparams::IntegrationParams{T2} =
         IntegrationParams(solver=Vern7(lazy=false))
 end
@@ -196,10 +196,10 @@ function propagate(waveguide::HomogeneousWaveguide, tx::Emitter, rx::AbstractSam
         end
 
         modeequation = PhysicalModeEquation(tx.frequency, waveguide)
-        modes = findmodes(modeequation, mesh, params=params)
+        modes = findmodes(modeequation, mesh; params=params)
     end
 
-    E = Efield(modes, waveguide, tx, rx, params=params)
+    E = Efield(modes, waveguide, tx, rx; params=params)
 
     amplitude, phase = amplitudephase(E)
 
@@ -246,7 +246,7 @@ function propagate(waveguide::SegmentedWaveguide, tx::Emitter, rx::AbstractSampl
 
         modeequation = PhysicalModeEquation(tx.frequency, wvg)
 
-        modes = findmodes(modeequation, mesh, params=params)
+        modes = findmodes(modeequation, mesh; params=params)
 
         # adjoint wavefields are wavefields through adjoint waveguide, but for same modes
         # as wavefield
@@ -255,7 +255,7 @@ function propagate(waveguide::SegmentedWaveguide, tx::Emitter, rx::AbstractSampl
         wavefields = Wavefields(params.wavefieldheights, modes)
         adjwavefields = Wavefields(params.wavefieldheights, modes)
 
-        calculate_wavefields!(wavefields, adjwavefields, tx.frequency, wvg, adjwvg,
+        calculate_wavefields!(wavefields, adjwavefields, tx.frequency, wvg, adjwvg;
                               params=params)
 
         wavefields_vec[j] = wavefields
@@ -263,7 +263,7 @@ function propagate(waveguide::SegmentedWaveguide, tx::Emitter, rx::AbstractSampl
         next!(pm)
     end
 
-    E = Efield(waveguide, wavefields_vec, adjwavefields_vec, tx, rx, params=params)
+    E = Efield(waveguide, wavefields_vec, adjwavefields_vec, tx, rx; params=params)
     next!(pm)
 
     # Efield for SegmentedWaveguides doesn't have a specialized form for AbstractSamplers
@@ -307,9 +307,9 @@ function propagate(file::AbstractString, outfile=missing; incrementalwrite=false
     if incrementalwrite
         s isa BatchInput || throw(ArgumentError("incrementalwrite only supported for"*
                                                 "BatchInput files"))
-        output = buildrunsave(outfile, s, append=append, mesh=mesh, unwrap=unwrap, params=params)
+        output = buildrunsave(outfile, s; append=append, mesh=mesh, unwrap=unwrap, params=params)
     else
-        output = buildrun(s, mesh=mesh, unwrap=unwrap, params=params)
+        output = buildrun(s; mesh=mesh, unwrap=unwrap, params=params)
 
         json_str = JSON3.write(output)
 

--- a/src/Waveguides.jl
+++ b/src/Waveguides.jl
@@ -53,9 +53,9 @@ struct SegmentedWaveguide{T<:Vector{<:Waveguide}} <: Waveguide
 end
 
 Base.length(w::SegmentedWaveguide) = length(w.v)
-Base.sort!(w::SegmentedWaveguide) = sort!(w.v, by=x->getfield(x, :distance))
+Base.sort!(w::SegmentedWaveguide) = sort!(w.v; by=x->getfield(x, :distance))
 Base.sort(w::SegmentedWaveguide) = SegmentedWaveguide(sort!(copy(w.v)))
-Base.issorted(w::SegmentedWaveguide) = issorted(w.v, by=x->getfield(x, :distance))
+Base.issorted(w::SegmentedWaveguide) = issorted(w.v; by=x->getfield(x, :distance))
 Base.size(w::SegmentedWaveguide) = size(w.v)
 Base.getindex(w::SegmentedWaveguide, i::Int) = w.v[i]
 Base.setindex(w::SegmentedWaveguide, x, i::Int) = (w.v[i] = x)

--- a/src/magnetoionic.jl
+++ b/src/magnetoionic.jl
@@ -117,9 +117,9 @@ function susceptibility(altitude, frequency, bfield, species; params=LMPParams()
 end
 
 susceptibility(altitude, me::ModeEquation; params=LMPParams()) =
-    susceptibility(altitude, me.frequency, me.waveguide, params=params)
+    susceptibility(altitude, me.frequency, me.waveguide; params=params)
 
 susceptibility(altitude, frequency, w::HomogeneousWaveguide; params=LMPParams()) =
-    susceptibility(altitude, frequency, w.bfield, w.species, params=params)
+    susceptibility(altitude, frequency, w.bfield, w.species; params=params)
 
 # TODO: Use a function approximation of susceptibility for each HomogeneousWaveguide?

--- a/src/modesum.jl
+++ b/src/modesum.jl
@@ -153,7 +153,7 @@ factor for electric fields can be found as:
 function excitationfactor(ea, dFdθ, R, efconstants::ExcitationFactor; params=LMPParams())
     S = ea.sinθ
     sqrtS = sqrt(S)
-    S₀ = referencetoground(ea.sinθ, params=params)
+    S₀ = referencetoground(ea.sinθ; params=params)
 
     @unpack F₁, F₂, F₃, F₄, h₁0, h₂0, Rg = efconstants
 
@@ -282,7 +282,7 @@ function modeterms(modeequation, tx::Emitter, rx::AbstractSampler; params=LMPPar
     @unpack ea, frequency, waveguide = modeequation
     @unpack ground = waveguide
 
-    ea₀ = referencetoground(ea, params=params)
+    ea₀ = referencetoground(ea; params=params)
     S₀ = ea₀.sinθ
 
     frequency == tx.frequency ||
@@ -301,20 +301,20 @@ function modeterms(modeequation, tx::Emitter, rx::AbstractSampler; params=LMPPar
     t2 = Sγ*Sϕ
     t3 = Sγ*Cϕ
 
-    dFdθ, R, Rg = solvedmodalequation(modeequation, params=params)
-    efconstants = excitationfactorconstants(ea₀, R, Rg, frequency, ground, params=params)
+    dFdθ, R, Rg = solvedmodalequation(modeequation; params=params)
+    efconstants = excitationfactorconstants(ea₀, R, Rg, frequency, ground; params=params)
 
-    λv, λb, λe = excitationfactor(ea, dFdθ, R, efconstants, params=params)
+    λv, λb, λe = excitationfactor(ea, dFdθ, R, efconstants; params=params)
 
     # Transmitter term
-    fzt, fyt, fxt = heightgains(zt, ea₀, frequency, efconstants, params=params)
+    fzt, fyt, fxt = heightgains(zt, ea₀, frequency, efconstants; params=params)
     txterm = λv*fzt*t1 + λb*fyt*t2 + λe*fxt*t3
 
     # Receiver term
     if zr == zt
         fzr, fyr, fxr = fzt, fyt, fxt
     else
-        fzr, fyr, fxr = heightgains(zr, ea₀, frequency, efconstants, params=params)
+        fzr, fyr, fxr = heightgains(zr, ea₀, frequency, efconstants; params=params)
     end
 
     # TODO: Handle multiple fields - maybe just always return all 3?
@@ -335,7 +335,7 @@ function modeterms(modeequation::ModeEquation, tx::Transmitter{VerticalDipole},
 
     @unpack ea, frequency, waveguide = modeequation
     @unpack ground = waveguide
-    ea₀ = referencetoground(ea, params=params)
+    ea₀ = referencetoground(ea; params=params)
     S₀ = ea₀.sinθ
 
     frequency == tx.frequency ||
@@ -343,14 +343,14 @@ function modeterms(modeequation::ModeEquation, tx::Transmitter{VerticalDipole},
 
     rxfield = fieldcomponent(rx)
 
-    dFdθ, R, Rg = solvedmodalequation(modeequation, params=params)
-    efconstants = excitationfactorconstants(ea₀, R, Rg, frequency, ground, params=params)
+    dFdθ, R, Rg = solvedmodalequation(modeequation; params=params)
+    efconstants = excitationfactorconstants(ea₀, R, Rg, frequency, ground; params=params)
 
-    λv, λb, λe = excitationfactor(ea, dFdθ, R, efconstants, params=params)
+    λv, λb, λe = excitationfactor(ea, dFdθ, R, efconstants; params=params)
 
     # Transmitter term
     # TODO: specialized heightgains for z = 0
-    fz, fy, fx = heightgains(0.0, ea₀, frequency, efconstants, params=params)
+    fz, fy, fx = heightgains(0.0, ea₀, frequency, efconstants; params=params)
     txterm = λv*fz
 
     # Receiver term
@@ -399,9 +399,9 @@ function Efield(modes, waveguide::HomogeneousWaveguide, tx::Emitter, rx::Abstrac
 
     for ea in modes
         modeequation = PhysicalModeEquation(ea, frequency, waveguide)
-        txterm, rxterm = modeterms(modeequation, tx, rx, params=params)
+        txterm, rxterm = modeterms(modeequation, tx, rx; params=params)
 
-        S₀ = referencetoground(ea.sinθ, params=params)
+        S₀ = referencetoground(ea.sinθ; params=params)
         expterm = -k*(S₀ - 1)
         txrxterm = txterm*rxterm
 
@@ -456,7 +456,7 @@ function Efield(modes, waveguide::HomogeneousWaveguide, tx::Emitter,
         modeequation = PhysicalModeEquation(ea, frequency, waveguide)
         txterm, rxterm = modeterms(modeequation, tx, rx, params=params)
 
-        S₀ = referencetoground(ea.sinθ, params=params)
+        S₀ = referencetoground(ea.sinθ; params=params)
         expterm = -k*(S₀ - 1)
         txrxterm = txterm*rxterm
 
@@ -525,7 +525,7 @@ function Efield(waveguide::SegmentedWaveguide, wavefields_vec, adjwavefields_vec
         if j > 1
             adjwavefields = adjwavefields_vec[j]
             prevwavefields = wavefields_vec[j-1]
-            conversioncoeffs = modeconversion(prevwavefields, wavefields, adjwavefields,
+            conversioncoeffs = modeconversion(prevwavefields, wavefields, adjwavefields;
                                               params=params)
         end
 
@@ -533,7 +533,7 @@ function Efield(waveguide::SegmentedWaveguide, wavefields_vec, adjwavefields_vec
         # segment
         for n = 1:N
             modeequation = PhysicalModeEquation(eas[n], frequency, wvg)
-            txterm, rxterm = modeterms(modeequation, tx, rx, params=params)
+            txterm, rxterm = modeterms(modeequation, tx, rx; params=params)
             if j == 1
                 # Transmitter exists only in the transmitter slab (obviously)
                 xmtrfields[n] = txterm
@@ -556,7 +556,7 @@ function Efield(waveguide::SegmentedWaveguide, wavefields_vec, adjwavefields_vec
 
             totalfield = zero(eltype(E))
             for n = 1:N
-                S₀ = referencetoground(eas[n].sinθ, params=params)
+                S₀ = referencetoground(eas[n].sinθ; params=params)
                 totalfield += rcvrfields[n]*cis(-k*x*(S₀ - 1))*factor
             end
 
@@ -573,7 +573,7 @@ function Efield(waveguide::SegmentedWaveguide, wavefields_vec, adjwavefields_vec
 
             resize!(previous_xmtrfields, N)
             for n = 1:N
-                S₀ = referencetoground(eas[n].sinθ, params=params)
+                S₀ = referencetoground(eas[n].sinθ; params=params)
 
                 # Excitation factors at end of slab
                 xmtrfields[n] *= cis(-k*x*(S₀ - 1))

--- a/test/Geophysics.jl
+++ b/test/Geophysics.jl
@@ -58,9 +58,9 @@ function test_waitprofile()
     end
 
     # Check if zero below cutoff height
-    @test waitprofile(30e3, 60, 0.35, cutoff_low=40e3) == 0
-    @test waitprofile(30e3, 60, 0.35, cutoff_low=40e3) isa Float64
-    @test waitprofile(30_000, 60, 0.35, cutoff_low=40e3) isa Float64
+    @test waitprofile(30e3, 60, 0.35; cutoff_low=40e3) == 0
+    @test waitprofile(30e3, 60, 0.35; cutoff_low=40e3) isa Float64
+    @test waitprofile(30_000, 60, 0.35; cutoff_low=40e3) isa Float64
 
     # Check default threshold
     @test waitprofile(110e3, 70, 0.5) == 1e12

--- a/test/LongwaveModePropagator.jl
+++ b/test/LongwaveModePropagator.jl
@@ -9,33 +9,33 @@ function test_propagate(scenario)
     @test eltype(phase) == Float64
 
     mesh = LMP.defaultmesh(tx.frequency)
-    E2, amp2, phase2 = propagate(waveguide, tx, rx, mesh=mesh)
+    E2, amp2, phase2 = propagate(waveguide, tx, rx; mesh=mesh)
     @test E2 ≈ E    rtol=1e-3
     @test amp2 ≈ amp    rtol=1e-3
     @test phase2 ≈ phase    rtol=1e-3
 
     me = PhysicalModeEquation(tx.frequency, waveguide)
     modes = findmodes(me, mesh)
-    E3, amp3, phase3 = propagate(waveguide, tx, rx, modes=modes)
+    E3, amp3, phase3 = propagate(waveguide, tx, rx; modes=modes)
     @test E3 ≈ E2    rtol=1e-3
     @test amp3 ≈ amp2    rtol=1e-3
     @test phase3 ≈ phase2    rtol=1e-3
 
     # mesh should be ignored
-    E4, amp4, phase4 = propagate(waveguide, tx, rx, modes=modes, mesh=[1.0])
+    E4, amp4, phase4 = propagate(waveguide, tx, rx; modes=modes, mesh=[1.0])
     @test E4 ≈ E3    rtol=1e-3
     @test amp4 ≈ amp3    rtol=1e-3
     @test phase4 ≈ phase3    rtol=1e-3
 
     # Are params being carried through?
     params = LMPParams(earthradius=6350e3)
-    E5, amp5, phase5 = propagate(waveguide, tx, rx, params=params)
+    E5, amp5, phase5 = propagate(waveguide, tx, rx; params=params)
     @test !isapprox(E5, E, rtol=1e-3)
     @test !isapprox(amp5, amp, rtol=1e-3)
     @test !isapprox(phase5, phase, rtol=1e-3)
 
     # Mismatch between modes and modeterms
-    E6, amp6, phase6 = propagate(waveguide, tx, rx, modes=modes, params=params)
+    E6, amp6, phase6 = propagate(waveguide, tx, rx; modes=modes, params=params)
     @test !isapprox(E6, E5, rtol=1e-3)
     @test !isapprox(amp6, amp5, rtol=1e-3)
     @test !isapprox(phase6, phase5, rtol=1e-3)
@@ -60,7 +60,7 @@ function test_propagate_segmented(scenario)
 
     # Are params being carried through?
     params = LMPParams(earthradius=6350e3)
-    E3, amp3, phase3 = propagate(waveguide, tx, rx, params=params)
+    E3, amp3, phase3 = propagate(waveguide, tx, rx; params=params)
     @test !isapprox(E3, E, rtol=1e-3)
     @test !isapprox(amp3, amp, rtol=1e-3)
     @test !isapprox(phase3, phase, rtol=1e-3)
@@ -76,7 +76,7 @@ function test_mcranges_segmented(scenario)
     waveguide = SegmentedWaveguide([HomogeneousWaveguide(bfield[i], species[i], ground[i],
                                                          distances[i]) for i in 1:2])
 
-    Eref, ampref, phaseref = propagate(waveguide, tx, rx, unwrap=false)
+    Eref, ampref, phaseref = propagate(waveguide, tx, rx; unwrap=false)
 
     E1, a1, p1 = propagate(waveguide, tx, GroundSampler(600e3, Fields.Ez))
     E2, a2, p2 = propagate(waveguide, tx, GroundSampler(1400e3, Fields.Ez))

--- a/test/bookerquartic.jl
+++ b/test/bookerquartic.jl
@@ -13,13 +13,13 @@ function test_bookerquarticM(scenario)
              M[2,1]             1-q[i]^2-S²+M[2,2]  M[2,3];
              S*q[i]+M[3,1]      M[3,2]              C²+M[3,3]]
 
-        @test LMP.isroot(det(G), atol=1e-5)  # real barely fails 1e-6 for resonant_scenario
+        @test LMP.isroot(det(G); atol=1e-5)  # real barely fails 1e-6 for resonant_scenario
     end
 
     # Confirm Booker quartic is directly satisfied
     for i in eachindex(q)
         booker = B[5]*q[i]^4 + B[4]*q[i]^3 + B[3]*q[i]^2 + B[2]*q[i] + B[1]
-        @test LMP.isroot(booker, atol=1e-6)
+        @test LMP.isroot(booker; atol=1e-6)
     end
 end
 
@@ -38,16 +38,16 @@ function test_bookerquarticT(scenario)
         G = [1-q[i]^2+M[1,1]    M[1,2]              S*q[i]+M[1,3];
              M[2,1]             1-q[i]^2-S²+M[2,2]  M[2,3];
              S*q[i]+M[3,1]      M[3,2]              C²+M[3,3]]
-        @test LMP.isroot(det(G), atol=1e-6)
+        @test LMP.isroot(det(G); atol=1e-6)
     end
 
     # eigvals is >20 times slower than bookerquartic
-    @test sort(eigvals(Array(T)), by=LMP.upgoing) ≈ sort(q, by=LMP.upgoing)
+    @test sort(eigvals(Array(T)); by=LMP.upgoing) ≈ sort(q; by=LMP.upgoing)
 
     # Confirm Booker quartic is directly satisfied
     for i in eachindex(q)
         booker = B[5]*q[i]^4 + B[4]*q[i]^3 + B[3]*q[i]^2 + B[2]*q[i] + B[1]
-        @test LMP.isroot(booker, atol=1e-6)
+        @test LMP.isroot(booker; atol=1e-6)
     end
 end
 
@@ -60,8 +60,8 @@ function test_bookerquartics(scenario)
     qM, BM = LMP.bookerquartic(ea, M)
     qT, BT = LMP.bookerquartic(T)
 
-    sort!(qM, by=LMP.upgoing)
-    sort!(qT, by=LMP.upgoing)
+    sort!(qM; by=LMP.upgoing)
+    sort!(qT; by=LMP.upgoing)
 
     @test qM ≈ qT
 end
@@ -73,10 +73,10 @@ function test_bookerquarticM_deriv(scenario)
 
     for i = 1:4
         qfcn(θ) = (ea = EigenAngle(θ); (q, B) = LMP.bookerquartic(ea, M);
-            sort!(q, by=LMP.upgoing); q[i])
+            sort!(q; by=LMP.upgoing); q[i])
         dqref = FiniteDiff.finite_difference_derivative(qfcn, θs, Val{:central})
         dq(θ) = (ea = EigenAngle(θ); (q, B) = LMP.bookerquartic(ea, M);
-            sort!(q, by=LMP.upgoing); LMP.dbookerquartic(ea, M, q, B)[i])
+            sort!(q; by=LMP.upgoing); LMP.dbookerquartic(ea, M, q, B)[i])
 
         @test maxabsdiff(dq.(θs), dqref) < 1e-6
     end

--- a/test/magnetoionic.jl
+++ b/test/magnetoionic.jl
@@ -2,8 +2,8 @@ function test_susceptibility(scenario)
     @unpack ea, tx, bfield, species, ground = scenario
 
     M1 = LMP.susceptibility(70e3, tx.frequency, bfield, species)
-    M2 = LMP.susceptibility(70e3, tx.frequency, bfield, species, params=LMPParams())
-    M3 = LMP.susceptibility(70e3, tx.frequency, bfield, species,
+    M2 = LMP.susceptibility(70e3, tx.frequency, bfield, species; params=LMPParams())
+    M3 = LMP.susceptibility(70e3, tx.frequency, bfield, species;
                              params=LMPParams(earthradius=6350e3))
     @test M1 == M2
     @test !(M2 ≈ M3)
@@ -12,13 +12,13 @@ function test_susceptibility(scenario)
     modeequation = PhysicalModeEquation(tx.frequency, waveguide)
 
     M4 = LMP.susceptibility(70e3, tx.frequency, waveguide)
-    M5 = LMP.susceptibility(70e3, tx.frequency, waveguide, params=LMPParams())
-    M6 = LMP.susceptibility(70e3, tx.frequency, waveguide,
+    M5 = LMP.susceptibility(70e3, tx.frequency, waveguide; params=LMPParams())
+    M6 = LMP.susceptibility(70e3, tx.frequency, waveguide;
                              params=LMPParams(earthradius=6350e3))
 
     M7 = LMP.susceptibility(70e3, modeequation)
-    M8 = LMP.susceptibility(70e3, modeequation, params=LMPParams())
-    M9 = LMP.susceptibility(70e3, modeequation,
+    M8 = LMP.susceptibility(70e3, modeequation; params=LMPParams())
+    M9 = LMP.susceptibility(70e3, modeequation;
                              params=LMPParams(earthradius=6350e3))
 
     @test M4 == M5 == M1

--- a/test/modeconversion.jl
+++ b/test/modeconversion.jl
@@ -15,7 +15,7 @@ function test_modeconversion_segmented(scenario)
         wvg = waveguide[i]
         adjwvg = LMP.adjoint(wvg)
         modeequation = PhysicalModeEquation(tx.frequency, wvg)
-        modes = findmodes(modeequation, mesh, params=params)
+        modes = findmodes(modeequation, mesh; params=params)
 
         wavefields = LMP.Wavefields(params.wavefieldheights, modes)
         adjwavefields = LMP.Wavefields(params.wavefieldheights, modes)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ const verticalB_scenario = (
     ea=EigenAngle(1.5 - 0.1im),
     bfield=BField(50e-6, π/2, 0),
     species=Species(QE, ME,
-                    z->waitprofile(z, 75, 0.32, cutoff_low=40e3),
+                    z->waitprofile(z, 75, 0.32; cutoff_low=40e3),
                     electroncollisionfrequency),
     ground=Ground(15, 0.001),
     tx=Transmitter(24e3),
@@ -36,7 +36,7 @@ const isotropicB_resonant_scenario = (
     ea=EigenAngle(1.453098822238508 - 0.042008075239068944im),  # resonant
     bfield=BField(50e-6, 0, π/2),
     species=Species(QE, ME,
-                    z->waitprofile(z, 75, 0.32, cutoff_low=40e3),
+                    z->waitprofile(z, 75, 0.32; cutoff_low=40e3),
                     electroncollisionfrequency),
     ground=Ground(15, 0.001),
     tx=Transmitter(24e3),
@@ -47,7 +47,7 @@ const resonant_scenario = (
     ea=EigenAngle(1.416127852502346 - 0.016482589477369265im),  # resonant
     bfield=BField(50e-6, deg2rad(68), deg2rad(111)),
     species=Species(QE, ME,
-                    z->waitprofile(z, 75, 0.32, cutoff_low=40e3),
+                    z->waitprofile(z, 75, 0.32; cutoff_low=40e3),
                     electroncollisionfrequency),
     ground=Ground(15, 0.001),
     tx=Transmitter(24e3),
@@ -58,7 +58,7 @@ const resonant_elevatedrx_scenario = (
     ea=EigenAngle(1.416127852502346 - 0.016482589477369265im),  # resonant
     bfield=BField(50e-6, deg2rad(68), deg2rad(111)),
     species=Species(QE, ME,
-                    z->waitprofile(z, 75, 0.32, cutoff_low=40e3),
+                    z->waitprofile(z, 75, 0.32; cutoff_low=40e3),
                     electroncollisionfrequency),
     ground=Ground(15, 0.001),
     tx=Transmitter(24e3),
@@ -69,7 +69,7 @@ const resonant_horizontal_scenario = (
     ea=EigenAngle(1.416127852502346 - 0.016482589477369265im),  # resonant
     bfield=BField(50e-6, deg2rad(68), deg2rad(111)),
     species=Species(QE, ME,
-                    z->waitprofile(z, 75, 0.32, cutoff_low=40e3),
+                    z->waitprofile(z, 75, 0.32; cutoff_low=40e3),
                     electroncollisionfrequency),
     ground=Ground(15, 0.001),
     tx=Transmitter(24e3),
@@ -80,7 +80,7 @@ const nonresonant_scenario = (
     ea=EigenAngle(1.5 - 0.1im),
     bfield=BField(50e-6, deg2rad(68), deg2rad(111)),
     species=Species(QE, ME,
-                    z->waitprofile(z, 75, 0.32, cutoff_low=40e3),
+                    z->waitprofile(z, 75, 0.32; cutoff_low=40e3),
                     electroncollisionfrequency),
     ground=Ground(5, 0.00005),
     tx=Transmitter(24e3),
@@ -102,10 +102,10 @@ const segmented_scenario = (
     ea=EigenAngle(1.5 - 0.1),
     bfield=[BField(50e-6, deg2rad(68), deg2rad(111)), BField(50e-6, deg2rad(68), deg2rad(111))],
     species=[Species(QE, ME,
-                     z->waitprofile(z, 75, 0.32, cutoff_low=40e3),
+                     z->waitprofile(z, 75, 0.32; cutoff_low=40e3),
                      electroncollisionfrequency),
              Species(QE, ME,
-                     z->waitprofile(z, 80, 0.45, cutoff_low=40e3),
+                     z->waitprofile(z, 80, 0.45; cutoff_low=40e3),
                      electroncollisionfrequency)],
     ground=[Ground(15, 0.001), Ground(15, 0.001)],
     tx=Transmitter(24e3),
@@ -113,8 +113,8 @@ const segmented_scenario = (
     distances=[0.0, 1000e3],
 )
 
-const θs = [complex(r,i) for r = range(deg2rad(60), deg2rad(89), length=30) for i =
-            range(deg2rad(-10), deg2rad(0), length=11)]
+const θs = [complex(r,i) for r = range(deg2rad(60), deg2rad(89); length=30) for i =
+            range(deg2rad(-10), deg2rad(0); length=11)]
 
 maxabsdiff(a, b) = maximum(abs.(a - b))
 meanabsdiff(a, b) = mean(abs.(a - b))

--- a/test/wavefields.jl
+++ b/test/wavefields.jl
@@ -73,7 +73,7 @@ function test_integratewavefields_homogeneous(scenario)
     ionobottom = params.curvatureheight
     zs = 200e3:-500:ionobottom
 
-    e = LMP.integratewavefields(zs, ea, tx.frequency, bfield, species, params=params)
+    e = LMP.integratewavefields(zs, ea, tx.frequency, bfield, species; params=params)
 
     # Normalize fields so component 2 (Ey) = 1, as is used in Booker Quartic
     e1 = [s[:,1]/s[2,1] for s in e]
@@ -83,11 +83,11 @@ function test_integratewavefields_homogeneous(scenario)
     e2 = reshape(reinterpret(ComplexF64, e2), 4, :)
 
     # Booker solution - single solution for entire homogeneous iono
-    M = LMP.susceptibility(ionobottom, tx.frequency, bfield, species, params=params)
+    M = LMP.susceptibility(ionobottom, tx.frequency, bfield, species; params=params)
     booker = LMP.bookerwavefields(ea, M)
 
-    @test isapprox(e1[:,end], booker[:,1], atol=1e-6)
-    @test isapprox(e2[:,end], booker[:,2], atol=1e-6)
+    @test isapprox(e1[:,end], booker[:,1]; atol=1e-6)
+    @test isapprox(e2[:,end], booker[:,2]; atol=1e-6)
 end
 
 function test_wavefieldreflection(scenario)
@@ -100,7 +100,7 @@ function test_wavefieldreflection(scenario)
 
     zs = params.wavefieldheights
 
-    e = LMP.integratewavefields(zs, ea, tx.frequency, bfield, species, params=params)
+    e = LMP.integratewavefields(zs, ea, tx.frequency, bfield, species; params=params)
     wavefieldRs = [LMP.bookerreflection(ea, s) for s in e]
 
     @unpack tolerance, solver = params.integrationparams
@@ -108,7 +108,7 @@ function test_wavefieldreflection(scenario)
     Mtop = LMP.susceptibility(first(zs), tx.frequency, waveguide)
     Rtop = LMP.bookerreflection(ea, Mtop)
     prob = ODEProblem{false}(LMP.dRdz, Rtop, (first(zs), last(zs)), (modeequation, params))
-    sol = solve(prob, solver, abstol=tolerance, reltol=tolerance,
+    sol = solve(prob, solver; abstol=tolerance, reltol=tolerance,
                 saveat=zs, save_everystep=false)
 
     @test isapprox(wavefieldRs, sol.u, rtol=1e-3)
@@ -121,7 +121,7 @@ function test_wavefieldreflection_resonant(scenario)
     ztop = params.topheight
     zs = ztop:-100:0.0
 
-    e = LMP.integratewavefields(zs, ea, tx.frequency, bfield, species, params=params)
+    e = LMP.integratewavefields(zs, ea, tx.frequency, bfield, species; params=params)
     R = LMP.bookerreflection(ea, e[end])
     Rg = LMP.fresnelreflection(ea, ground, tx.frequency)
 
@@ -141,7 +141,7 @@ function test_boundaryscalars(scenario)
     ztop = params.topheight
     zs = ztop:-100:0.0
 
-    e = LMP.integratewavefields(zs, ea, tx.frequency, bfield, species, params=params)
+    e = LMP.integratewavefields(zs, ea, tx.frequency, bfield, species; params=params)
     R = LMP.bookerreflection(ea, e[end])
     Rg = LMP.fresnelreflection(ea, ground, tx.frequency)
 


### PR DESCRIPTION
I often simply separated keyword arguments from regular positional arguments with a comma, e.g. `afcn(2.3, 4.3, a=13.0, b=0.9)`, but the preferred syntax is to separate with a semicolon: `afcn(2.3, 4.3; a=13.0, b=0.9)`. In upcoming Julia 1.6 this would allow doing things like `afcn(2.3, 4.3, a=a, b=b)` as `afcn(2.3, 4.3; a, b)`.

This PR introduces semicolons to separate keyword arguments throughout the source, tests, and examples.