### PR TITLE
Interpolating spline for susceptibility

### DIFF
--- a/src/LongwaveModePropagator.jl
+++ b/src/LongwaveModePropagator.jl
@@ -88,6 +88,8 @@ Parameters for the `LongwaveModePropagator` module with defaults:
     eigenangles.
 - `approxsusceptibility::Bool = false`: use a cubic interpolating spline representation of
     [`susceptibility`](@ref) during the integration of [`dRdz`](@ref).
+- `susceptibilitysplinestep::Float64 = 10.0`: altitude step in meters used to build the
+    cubic spline representation of [`susceptibility`](@ref) if `approxsusceptibility == true`.
 - `grpfparams::GRPFParams = GRPFParams(100000, 1e-5, true)`: parameters for the `GRPF`
     complex root-finding algorithm.
 - `integrationparams::IntegrationParams{T} =
@@ -116,6 +118,7 @@ p3 = LMPParams(p2; grpf_params=GRPFParams(100000, 1e-6, true))
     earthcurvature::Bool = true
     curvatureheight::Float64 = 50e3  # m
     approxsusceptibility::Bool = false
+    susceptibilitysplinestep::Float64 = 10.0
     grpfparams::GRPFParams = DEFAULT_GRPFPARAMS
     integrationparams::IntegrationParams{T} = IntegrationParams()
     wavefieldheights::H = range(topheight, 0; length=513)

--- a/src/LongwaveModePropagator.jl
+++ b/src/LongwaveModePropagator.jl
@@ -86,6 +86,8 @@ Parameters for the `LongwaveModePropagator` module with defaults:
 - `curvatureheight::Float64 = 50e3`: reference height for Earth curvature in meters. At this
     height, the index of refraction is 1, and is therefore the reference height for
     eigenangles.
+- `approxsusceptibility::Bool = false`: use a cubic interpolating spline representation of
+    [`susceptibility`](@ref) during the integration of [`dRdz`](@ref).
 - `grpfparams::GRPFParams = GRPFParams(100000, 1e-5, true)`: parameters for the `GRPF`
     complex root-finding algorithm.
 - `integrationparams::IntegrationParams{T} =
@@ -113,6 +115,7 @@ p3 = LMPParams(p2; grpf_params=GRPFParams(100000, 1e-6, true))
     earthradius::Float64 = 6369e3  # m
     earthcurvature::Bool = true
     curvatureheight::Float64 = 50e3  # m
+    approxsusceptibility::Bool = false
     grpfparams::GRPFParams = DEFAULT_GRPFPARAMS
     integrationparams::IntegrationParams{T} = IntegrationParams()
     wavefieldheights::H = range(topheight, 0; length=513)

--- a/src/magnetoionic.jl
+++ b/src/magnetoionic.jl
@@ -112,4 +112,28 @@ susceptibility(altitude, me::ModeEquation; params=LMPParams()) =
 susceptibility(altitude, frequency, w::HomogeneousWaveguide; params=LMPParams()) =
     susceptibility(altitude, frequency, w.bfield, w.species; params=params)
 
-# TODO: Use a function approximation of susceptibility for each HomogeneousWaveguide?
+"""
+    susceptibilityspline(frequency, bfield, species; params=LMPParams(), zstep=10.0)
+    susceptibilityspline(frequency, w::HomogeneousWaveguide; params=LMPParams(), zstep=10.0)
+    susceptibilityspline(me::ModeEquation; params=LMPParams(), zstep=10.0)
+
+Construct a cubic interpolating spline of [`susceptibility`](@ref) and return the callable
+`Interpolations` type.
+
+`zstep` is the altitude step in meters used to construct the spline between `BOTTOMHEIGHT`
+and `params.topheight`.
+"""
+function susceptibilityspline(frequency, bfield, species; params=LMPParams(), zstep=10.0)
+    zs = BOTTOMHEIGHT:zstep:params.topheight
+    Ms = susceptibility.(zs, (frequency,), (bfield,), (species,))
+
+    itp = CubicSplineInterpolation(zs, Ms)
+
+    return itp
+end
+
+susceptibilityspline(me::ModeEquation; params=LMPParams(), zstep=10.0) =
+    susceptibilityspline(me.frequency, me.waveguide; params=params, zstep=zstep)
+
+susceptibilityspline(frequency, w::HomogeneousWaveguide; params=LMPParams(), zstep=10.0) =
+    susceptibilityspline(frequency, w.bfield, w.species; params=params, zstep=zstep)

--- a/src/magnetoionic.jl
+++ b/src/magnetoionic.jl
@@ -113,18 +113,18 @@ susceptibility(altitude, frequency, w::HomogeneousWaveguide; params=LMPParams())
     susceptibility(altitude, frequency, w.bfield, w.species; params=params)
 
 """
-    susceptibilityspline(frequency, bfield, species; params=LMPParams(), zstep=10.0)
-    susceptibilityspline(frequency, w::HomogeneousWaveguide; params=LMPParams(), zstep=10.0)
-    susceptibilityspline(me::ModeEquation; params=LMPParams(), zstep=10.0)
+    susceptibilityspline(frequency, bfield, species; params=LMPParams())
+    susceptibilityspline(frequency, w::HomogeneousWaveguide; params=LMPParams())
+    susceptibilityspline(me::ModeEquation; params=LMPParams())
 
 Construct a cubic interpolating spline of [`susceptibility`](@ref) and return the callable
 `Interpolations` type.
 
-`zstep` is the altitude step in meters used to construct the spline between `BOTTOMHEIGHT`
-and `params.topheight`.
+`params.susceptibilitysplinestep` is the altitude step in meters used to construct the
+spline between `BOTTOMHEIGHT` and `params.topheight`.
 """
-function susceptibilityspline(frequency, bfield, species; params=LMPParams(), zstep=10.0)
-    zs = BOTTOMHEIGHT:zstep:params.topheight
+function susceptibilityspline(frequency, bfield, species; params=LMPParams())
+    zs = BOTTOMHEIGHT:params.susceptibilitysplinestep:params.topheight
     Ms = susceptibility.(zs, (frequency,), (bfield,), (species,))
 
     itp = CubicSplineInterpolation(zs, Ms)
@@ -132,8 +132,8 @@ function susceptibilityspline(frequency, bfield, species; params=LMPParams(), zs
     return itp
 end
 
-susceptibilityspline(me::ModeEquation; params=LMPParams(), zstep=10.0) =
-    susceptibilityspline(me.frequency, me.waveguide; params=params, zstep=zstep)
+susceptibilityspline(me::ModeEquation; params=LMPParams()) =
+    susceptibilityspline(me.frequency, me.waveguide; params=params)
 
-susceptibilityspline(frequency, w::HomogeneousWaveguide; params=LMPParams(), zstep=10.0) =
-    susceptibilityspline(frequency, w.bfield, w.species; params=params, zstep=zstep)
+susceptibilityspline(frequency, w::HomogeneousWaveguide; params=LMPParams()) =
+    susceptibilityspline(frequency, w.bfield, w.species; params=params)

--- a/src/modefinder.jl
+++ b/src/modefinder.jl
@@ -283,27 +283,26 @@ function dRdθdz(RdRdθ, p, z)
 end
 
 """
-    integratedreflection(modeequation::PhysicalModeEquation; params=LMPParams())
+    integratedreflection(modeequation::PhysicalModeEquation;
+        params=LMPParams(), susceptibilityfcn=z->susceptibility(z, modeequation; params=params))
 
 Integrate ``dR/dz`` downward through the ionosphere described by `modeequation` from
 `params.topheight`, returning the ionosphere reflection coefficient `R` at the ground.
+`susceptibilityfcn` is a function returning the ionosphere susceptibility tensor as a
+function of altitude `z` in meters.
 
 `params.integrationparams` are passed to `DifferentialEquations.jl`.
 """
-function integratedreflection(modeequation::PhysicalModeEquation; params=LMPParams())
-    @unpack topheight, approxsusceptibility, integrationparams = params
+function integratedreflection(modeequation::PhysicalModeEquation;
+    params=LMPParams(), susceptibilityfcn=z->susceptibility(z, modeequation; params=params))
+
+    @unpack topheight, integrationparams = params
     @unpack tolerance, solver, dt, force_dtmin, maxiters = integrationparams
 
     Mtop = susceptibility(topheight, modeequation; params=params)
     Rtop = bookerreflection(modeequation.ea, Mtop)
 
-    if approxsusceptibility
-        Mfcn = susceptibilityspline(modeequation; params=params)
-    else
-        Mfcn = z -> susceptibility(z, modeequation; params=params)
-    end
-
-    prob = ODEProblem{false}(dRdz, Rtop, (topheight, BOTTOMHEIGHT), (modeequation, Mfcn))
+    prob = ODEProblem{false}((R,p,z)->dRdz(R,p,z,susceptibilityfcn), Rtop, (topheight, BOTTOMHEIGHT), modeequation)
 
     # WARNING: When save_on=false, don't try interpolating the solution!
     sol = solve(prob, solver; abstol=tolerance, reltol=tolerance,
@@ -356,7 +355,6 @@ ground.
 fresnelreflection
 
 function fresnelreflection(ea::EigenAngle, ground::Ground, frequency::Frequency)
-
     C, S² = ea.cosθ, ea.sin²θ
     ω = frequency.ω
 
@@ -447,15 +445,19 @@ function dmodalequation(R, dR, Rg, dRg)
 end
 
 """
-    solvemodalequation(modeequation::PhysicalModeEquation; params=LMPParams())
+    solvemodalequation(modeequation::PhysicalModeEquation;
+        params=LMPParams(), susceptibilityfcn=z->susceptibility(z, modeequation; params=params))
 
 Compute the ionosphere and ground reflection coefficients and return the value of the
-determinental modal equation associated with `modeequation`.
+determinental modal equation associated with `modeequation`. `susceptibilityfcn` is a
+function that returns the ionosphere susceptibility as a function of altitude `z` in meters.
 
 See also: [`solvedmodalequation`](@ref)
 """
-function solvemodalequation(modeequation::PhysicalModeEquation; params=LMPParams())
-    R = integratedreflection(modeequation; params=params)
+function solvemodalequation(modeequation::PhysicalModeEquation;
+    params=LMPParams(), susceptibilityfcn=z->susceptibility(z, modeequation; params=params))
+
+    R = integratedreflection(modeequation; params=params, susceptibilityfcn=susceptibilityfcn)
     Rg = fresnelreflection(modeequation)
 
     f = modalequation(R, Rg)
@@ -463,14 +465,17 @@ function solvemodalequation(modeequation::PhysicalModeEquation; params=LMPParams
 end
 
 """
-    solvemodalequation(θ, modeequation::PhysicalModeEquation; params=LMPParams())
+    solvemodalequation(θ, modeequation::PhysicalModeEquation;
+        params=LMPParams(), susceptibilityfcn=z->susceptibility(z, modeequation; params=params))
 
 Set `θ` for `modeequation` and then solve the modal equation.
 """
-function solvemodalequation(θ, modeequation::PhysicalModeEquation; params=LMPParams())
+function solvemodalequation(θ, modeequation::PhysicalModeEquation;
+    params=LMPParams(), susceptibilityfcn=z->susceptibility(z, modeequation; params=params))
+
     # Convenience function for `grpf`
     modeequation = setea(EigenAngle(θ), modeequation)
-    solvemodalequation(modeequation; params=params)
+    solvemodalequation(modeequation; params=params, susceptibilityfcn=susceptibilityfcn)
 end
 
 """
@@ -523,7 +528,7 @@ component. For example, if `grpfparams.tolerance = 1e-5`, then either the real o
 component of each mode must be separated by at least 1e-3 from every other mode.
 """
 function findmodes(modeequation::ModeEquation, origcoords=nothing; params=LMPParams())
-    @unpack grpfparams = params
+    @unpack approxsusceptibility, grpfparams = params
 
     if isnothing(origcoords)
         origcoords = defaultmesh(modeequation.frequency)
@@ -533,8 +538,14 @@ function findmodes(modeequation::ModeEquation, origcoords=nothing; params=LMPPar
     # is possible multiple identical modes will be identified. Checks for valid and
     # redundant modes help ensure valid eigenangles are returned from this function.
 
-    roots, poles = grpf(θ->solvemodalequation(θ, modeequation; params=params),
-                        origcoords, grpfparams)
+    if approxsusceptibility
+        susceptibilityfcn = susceptibilityspline(modeequation; params=params)
+    else
+        susceptibilityfcn = z -> susceptibility(z, modeequation; params=params)
+    end
+
+    roots, poles = grpf(θ->solvemodalequation(θ, modeequation;
+        params=params, susceptibilityfcn=susceptibilityfcn), origcoords, grpfparams)
 
     # Scale tolerance for filtering
     # if tolerance is 1e-8, this rounds to 6 decimal places

--- a/test/magnetoionic.jl
+++ b/test/magnetoionic.jl
@@ -30,11 +30,45 @@ function test_susceptibility(scenario)
     @inferred LMP.susceptibility(70e3, tx.frequency, bfield, species)
 end
 
+function test_spline(scenario)
+    @unpack ea, tx, bfield, species, ground = scenario
+
+    itp = LMP.susceptibilityspline(tx.frequency, bfield, species)
+
+    zs = LMP.BOTTOMHEIGHT:1:LMPParams().topheight
+    Ms = LMP.susceptibility.(zs, (tx.frequency,), (bfield,), (species,))
+    Mitp = itp.(zs)
+
+    function matrix(M)
+        mat = Matrix{eltype(M[1])}(undef, length(M), 9)
+        for i in eachindex(M)
+            mat[i,:] = M[i]
+        end
+        return mat
+    end
+
+    @test matrix(Mitp) ≈ matrix(Ms) rtol=1e-5
+
+    # plot(matrix(real(Ms)), zs/1000, legend=false)
+    # plot!(matrix(real(Mitp)), zs/1000, linestyle=:dash)
+
+    # Mdiff = matrix(real(Ms)) .- matrix(real(Mitp))
+    # scaleddiff = Mdiff./matrix(real(Ms))
+    # plot(Mdiff, zs/1000, legend=false, ylims=(0,110))
+
+    # Make sure `params.susceptibilitysplinestep` is being used
+    itp2 = LMP.susceptibilityspline(tx.frequency, bfield, species; params=LMPParams(susceptibilitysplinestep=10.0))
+    itp3 = LMP.susceptibilityspline(tx.frequency, bfield, species; params=LMPParams(susceptibilitysplinestep=20.0))
+    @test itp == itp2
+    @test itp != itp3
+end
+
 @testset "magnetoionic.jl" begin
     @info "Testing magnetoionic"
 
     for scn in (verticalB_scenario, resonant_scenario, nonresonant_scenario,
             multiplespecies_scenario)
         test_susceptibility(scn)
+        test_spline(scn)
     end
 end

--- a/test/modefinder.jl
+++ b/test/modefinder.jl
@@ -213,7 +213,7 @@ function test_solvemodalequation(scenario)
     f4 = @inferred LMP.solvemodalequation(me; susceptibilityfcn=Mfcn2)
 
     @test f == f3
-    @test maxabsdiff(f, f4) < 1e-6
+    @test maxabsdiff(f, f4) < 1e-5
 end
 
 function test_modalequation_resonant(scenario)
@@ -268,7 +268,9 @@ function test_findmodes(scenario)
     modes2 = @inferred findmodes(modeequation, origcoords; params=LMPParams(params; approxsusceptibility=true))
 
     @test length(modes) == length(modes2)
-    @test all(maxabsdiff(modes[i].θ, modes2[i].θ) < 1e-5 for i in 1:length(modes))
+
+    # 5e-4 needed to accomodate multiplespecies_scenario. Otherwise they satisfy 1e-5
+    @test all(maxabsdiff(modes[i].θ, modes2[i].θ) < 5e-4 for i in 1:length(modes))
 
     for m in modes
         f = LMP.solvemodalequation(m, modeequation; params=params)

--- a/test/modefinder.jl
+++ b/test/modefinder.jl
@@ -58,7 +58,21 @@ function test_dRdz(scenario)
     Rtop = LMP.bookerreflection(ea, Mtop)
 
     # sharply bounded R from bookerreflection satisfies dR/dz = 0
-    @test isapprox(LMP.dRdz(Rtop, (me, params), params.topheight), zeros(2, 2); atol=1e-15)
+    @test isapprox(LMP.dRdz(Rtop, me, params.topheight), zeros(2, 2); atol=1e-15)
+
+    # Compare default and optional argument
+    M = LMP.susceptibility(72e3, me; params=params)
+    R = LMP.bookerreflection(ea, M)
+    dR1 = @inferred LMP.dRdz(R, me, 72e3)
+
+    Mfcn = z -> LMP.susceptibility(z, me; params=params)
+    dR2 = @inferred LMP.dRdz(R, me, 72e3, Mfcn)
+
+    Mfcn2 = LMP.susceptibilityspline(me; params=params)
+    dR3 = @inferred LMP.dRdz(R, me, 72e3, Mfcn2)
+
+    @test dR1 == dR2  # identical functions Mfcn
+    @test isapprox(dR1, dR3, atol=1e-12)  # interpolating spline
 end
 
 function test_dRdθdz(scenario)

--- a/test/wavefields.jl
+++ b/test/wavefields.jl
@@ -107,7 +107,7 @@ function test_wavefieldreflection(scenario)
 
     Mtop = LMP.susceptibility(first(zs), tx.frequency, waveguide)
     Rtop = LMP.bookerreflection(ea, Mtop)
-    prob = ODEProblem{false}(LMP.dRdz, Rtop, (first(zs), last(zs)), (modeequation, params))
+    prob = ODEProblem{false}(LMP.dRdz, Rtop, (first(zs), last(zs)), modeequation)
     sol = solve(prob, solver; abstol=tolerance, reltol=tolerance,
                 saveat=zs, save_everystep=false)
 


### PR DESCRIPTION
This PR closes #28 by adding the ability to build a cubic interpolating spline for `susceptibility` for mode finding only (in `dRdz`). It decreases the runtime of `findmodes` by 20%. Wavefield computations and derivatives with respect to θ continue to use `susceptibility` directly.

The interpolating version of `susceptibility` can be activated by specifying the `params` argument with `LMPParams(approxsusceptibility=true)`. Additionally, the altitude step size used in the creation of the interpolating spline can be specified as `LMPParams(susceptibilitysplinestep=10.0)`. By default the initial step is 10 meters.

By default, `approxsusceptibility=false` so that this PR does not introduce breaking behavior. However, if anyone is specifying fields of `LMPParams` directly without keyword arguments (not recommended), this _is_ a breaking change because we've introduced new fields to the `LMPParams` struct. 

