### PR TITLE
Modesearch defaults

### DIFF
--- a/examples/meshgrid2.jl
+++ b/examples/meshgrid2.jl
@@ -161,7 +161,7 @@ plot!(img, real(polesdeg), imag(polesdeg); color="red",
 # a variety of ionospheres. To ensure they are captured,
 # [`LongwaveModePropagator.defaultmesh`](@ref)
 # uses a spacing of `Δr = deg2rad(0.5)` for most of the mesh,
-# but a spacing of `Δr = deg2rad(0.15)` for the region with real greater
+# but a spacing of `Δr = deg2rad(0.1)` for the region with real greater
 # than 75° and imaginary greater than -1.5°.
 
 mesh = defaultmesh(frequency)

--- a/examples/wavefieldintegration.jl
+++ b/examples/wavefieldintegration.jl
@@ -148,6 +148,7 @@ plot!(p2, real(hx2_unscaled),
 plot(p1, p2; layout=(1,2))
 #md savefig("wavefields_scaling.png"); nothing #hide
 #md # ![](wavefields_scaling.png)
+# 
 
 # ## Differential equations solver
 #
@@ -178,7 +179,7 @@ solverstrings = replace.(string.(solvers), "OrdinaryDiffEq."=>"")
 day_es = []
 night_es = []
 for s in eachindex(solvers)
-    ip = IntegrationParams(solver=solvers[s], tolerance=1e-8)
+    ip = IntegrationParams(solver=solvers[s], tolerance=1e-6)
     params = LMPParams(wavefieldintegrationparams=ip)
 
     ## make sure method is compiled
@@ -187,8 +188,8 @@ for s in eachindex(solvers)
 
     solverstring = solverstrings[s]
     let day_e, night_e
-        ## repeat 25 times to average calls
-        for i = 1:25
+        ## repeat 200 times to average calls
+        for i = 1:200
             ## day ionosphere
             @timeit TO solverstring begin
                 day_e = LMP.integratewavefields(zs, ea, frequency, bfield, day; params=params)
@@ -231,13 +232,8 @@ TO
 # In fact, rerunning these same tests multiple times can result in different solvers
 # being "fastest".
 #
-# The DifferentialEquations [documents](https://diffeq.sciml.ai/stable/solvers/ode_solve/)
-# suggest that Verner's methods are preferred over the two lower order methods when solving
-# with the accuracy range `~1e-8-1e-12`. We use `Vern7(lazy=false)`as the default in
-# LongwaveModePropagator. There is no direct MATLAB equivalent to `Vern7`; it
-# plays a similar role as [`ode113`](https://www.mathworks.com/help/matlab/ref/ode113.html)
-# (Mathworks suggests `ode113` is better at solving problems with stringent error tolerance
-# than `ode45`). `Vern7` is usually more efficient than `ode113`.
+# We use `Tsit5()`as the default in LongwaveModePropagator, which is similar to MATLAB's
+# `ode45`, but usually more efficient.
 #
 # Why not a strict `RK4` or a more basic method? I tried them and they produce some
 # discontinuities around the reflection height. It is admittedly difficult to tell
@@ -283,6 +279,7 @@ annotate!(hx2p, 0.35, 84, text("\$H_{x,2}\$", fs, :center));
 plot(ex1p, ey1p, ex2p, hx2p; layout=(2,2), size=(400,600), top_margin=5mm)
 #md savefig("wavefields_fig2.png"); nothing #hide
 #md # ![](wavefields_fig2.png)
+# 
 
 # ```@raw html
 # <img src="../../images/Pitteway1965_fig2.png"/>
@@ -322,6 +319,7 @@ hx2p = plotfield(hx2; ylims=(75, 102), title="\$H_{x,2}\$");
 plot(ey1p, hx2p; layout=(1,2), size=(400,500))
 #md savefig("wavefields_fig3.png"); nothing #hide
 #md # ![](wavefields_fig3.png)
+# 
 
 # ```@raw html
 # <img src="../../images/Pitteway1965_fig3.png"/>

--- a/src/LongwaveModePropagator.jl
+++ b/src/LongwaveModePropagator.jl
@@ -60,7 +60,7 @@ coefficient matrix in `modefinder.jl`.
 - `maxiters::Int = 100_000`: maximum number of iterations before stopping.
 """
 @with_kw struct IntegrationParams{T}
-    tolerance::Float64 = 1e-8
+    tolerance::Float64 = 1e-5
     solver::T = Vern7()
     dt::Float64 = 1.0
     force_dtmin::Bool = false

--- a/src/LongwaveModePropagator.jl
+++ b/src/LongwaveModePropagator.jl
@@ -90,13 +90,13 @@ Parameters for the `LongwaveModePropagator` module with defaults:
 - `grpfparams::GRPFParams = GRPFParams(100000, 1e-5, true)`: parameters for the `GRPF`
     complex root-finding algorithm.
 - `integrationparams::IntegrationParams{T} =
-    IntegrationParams(solver=Vern7(), tolerance=1e-8)`:
+    IntegrationParams(solver=Vern7(), tolerance=1e-5)`:
     parameters passed to `DifferentialEquations.jl` for integration of the ionosphere
     reflection coefficient.
 - `wavefieldheights::H = range(topheight, 0, length=513)`: heights in meters at which
     wavefields will be integrated.
 - `wavefieldintegrationparams::IntegrationParams{T2} =
-    IntegrationParams(solver=Vern7(lazy=false), tolerance=1e-8)`:
+    IntegrationParams(solver=Tsit5(), tolerance=1e-6)`:
     parameters passed to `DifferentialEquations.jl` for integration of the wavefields
     used in mode conversion. The solver cannot be lazy.
 
@@ -122,7 +122,7 @@ See also: [`IntegrationParams`](@ref)
     integrationparams::IntegrationParams{T} = IntegrationParams()
     wavefieldheights::H = range(topheight, 0; length=513)
     wavefieldintegrationparams::IntegrationParams{T2} =
-        IntegrationParams(solver=Vern7(lazy=false))
+        IntegrationParams(solver=Tsit5(), tolerance=1e-6)
 end
 export LMPParams
 

--- a/src/LongwaveModePropagator.jl
+++ b/src/LongwaveModePropagator.jl
@@ -52,7 +52,7 @@ coefficient matrix in `modefinder.jl`.
 
 # Fields
 
-- `tolerance::Float64 = 1e-8`: integration `atol` and `rtol`.
+- `tolerance::Float64 = 1e-5`: integration `atol` and `rtol`.
 - `solver::T = Vern7()`: a `DifferentialEquations.jl` solver.
 - `dt::Float64 = 1.0`: height step in meters (many methods use a variable step size).
 - `force_dtmin::Bool = false`: if true, continue integration when solver reaches minimum

--- a/src/Wavefields.jl
+++ b/src/Wavefields.jl
@@ -349,7 +349,8 @@ savevalues(u, t, integrator) = ScaleRecord(integrator.p.z,
 
 Compute wavefields vectors `e` at `zs` by downward integration over heights `zs`.
 
-`params.integrationparams` is not used by this function.
+`params.wavefieldintegrationparams` is used by this function rather than
+`params.integrationparams`.
 """
 function integratewavefields(zs, ea::EigenAngle, frequency::Frequency, bfield::BField,
     species; params=LMPParams(), unscale=true)

--- a/src/bookerquartic.jl
+++ b/src/bookerquartic.jl
@@ -382,11 +382,11 @@ an upgoing and downgoing wave, each of which is generally elliptically polarized
 the amplitudes of these two waves give a reflection coefficient, except it would only apply
 for an incident wave of that particular elliptical polarization. However, the first set of
 fields can be linearly combined with a second independent solution for the fields, which
-will generally have a elliptical polarization than the first. Two linear combinations of the
-two sets of fields are formed with unit amplitude, linearly polarized incident waves. The
-reflected waves then give the components ``R₁₁``, ``R₂₁`` or ``R₁₂``, ``R₂₂`` for the
-incident wave in the plane of incidence and perpendicular to it, respectively
-[Budden1988] pg 552.
+will generally have a different elliptical polarization than the first. Two linear
+combinations of the two sets of fields are formed with unit amplitude, linearly polarized
+incident waves. The reflected waves then give the components ``R₁₁``, ``R₂₁`` or ``R₁₂``,
+``R₂₂`` for the incident wave in the plane of incidence and perpendicular to it,
+respectively [Budden1988] pg 552.
 
 The process for determining the reflection coefficient requires resolving the two sets of
 fields ``e₁`` and ``e₂`` into the four linearly polarized vacuum modes. The layer of vacuum
@@ -400,7 +400,7 @@ For ``e₁`` and ``e₂``, we can find the corresponding vectors ``f1`` and ``f2
 ``f1 = (u1, d1)ᵀ`` and ``f2 = (u2, d2)ᵀ`` for upgoing and downgoing 2-element vectors ``u``
 and ``d``. From the definition of the reflection coefficient ``R``, ``d = Ru``. Letting
 ``U = (u1, u2)``, ``D = (d1, d2)``, then ``D = RU`` and the reflection coefficient is
-``R = DU¹``. Because the reflection coefficient matrix is a ratio of fields, either ``e₁``
+``R = DU⁻¹``. Because the reflection coefficient matrix is a ratio of fields, either ``e₁``
 and/or ``e₂`` can be independently multiplied by an arbitrary constant and the value of
 ``R`` is unaffected.
 

--- a/src/modefinder.jl
+++ b/src/modefinder.jl
@@ -482,13 +482,13 @@ function solvedmodalequation(θ, modeequation::PhysicalModeEquation; params=LMPP
 end
 
 """
-    findmodes(modeequation::ModeEquation, origcoords=nothing; params=LMPParams())
+    findmodes(modeequation::ModeEquation, mesh=nothing; params=LMPParams())
 
 Find `EigenAngle`s associated with `modeequation.waveguide` within the domain of
-`origcoords`.
+`mesh`.
 
-`origcoords` should be an array of complex numbers that make up the original grid over which
-the GRPF algorithm searches for roots of `modeequation`. If `origcoords == nothing`,
+`mesh` should be an array of complex numbers that make up the original grid over which
+the GRPF algorithm searches for roots of `modeequation`. If `mesh === nothing`,
 it is computed with [`defaultmesh`](@ref).
 
 There is a check for redundant modes that requires modes to be separated by at least
@@ -496,11 +496,11 @@ There is a check for redundant modes that requires modes to be separated by at l
 component. For example, if `grpfparams.tolerance = 1e-5`, then either the real or imaginary
 component of each mode must be separated by at least 1e-4 from every other mode.
 """
-function findmodes(modeequation::ModeEquation, origcoords=nothing; params=LMPParams())
+function findmodes(modeequation::ModeEquation, mesh=nothing; params=LMPParams())
     @unpack approxsusceptibility, grpfparams = params
 
-    if isnothing(origcoords)
-        origcoords = defaultmesh(modeequation.frequency)
+    if isnothing(mesh)
+        mesh = defaultmesh(modeequation.frequency)
     end
 
     # WARNING: If tolerance of mode finder is much less than the R integration tolerance, it
@@ -514,7 +514,7 @@ function findmodes(modeequation::ModeEquation, origcoords=nothing; params=LMPPar
     end
 
     roots, _ = grpf(θ->solvemodalequation(θ, modeequation;
-        params=params, susceptibilityfcn=susceptibilityfcn), origcoords, grpfparams)
+        params=params, susceptibilityfcn=susceptibilityfcn), mesh, grpfparams)
 
     # Scale tolerance for filtering
     # if tolerance is 1e-8, this rounds to 7 decimal places
@@ -533,7 +533,7 @@ Mesh grids for `GRPF`
 
 """
     defaultmesh(frequency; rmin=deg2rad(30.0), imin=deg2rad(-10.0),
-        Δr_coarse=deg2rad(0.5), Δr_fine=deg2rad(0.15),
+        Δr_coarse=deg2rad(0.5), Δr_fine=deg2rad(0.1),
         rtransition=deg2rad(75.0), itransition=deg2rad(-1.5))
 
 Generate vector of complex coordinates to be used by GRPF in the search for
@@ -555,7 +555,7 @@ See also: [`findmodes`](@ref)
 """
 function defaultmesh(frequency;
     rmin=deg2rad(30.0), imin=deg2rad(-10.0),
-    Δr_coarse=deg2rad(0.5), Δr_fine=deg2rad(0.15),
+    Δr_coarse=deg2rad(0.5), Δr_fine=deg2rad(0.1),
     rtransition=deg2rad(75.0), itransition=deg2rad(-1.5))
 
     # TODO: get a better idea of frequency transition

--- a/src/modefinder.jl
+++ b/src/modefinder.jl
@@ -286,10 +286,18 @@ end
 
 Compute ``R`` and ``dR/dθ`` as an `SMatrix{4,2}` with ``R`` in rows (1, 2) and ``dR/dθ`` in
 rows (3, 4).
+
+The `params.integrationparams.tolerance` is hardcoded to `1e-10` in this version of the
+function.
 """
 function integratedreflection(modeequation::PhysicalModeEquation, ::Dθ; params=LMPParams())
     @unpack topheight, integrationparams = params
-    @unpack tolerance, solver, dt, force_dtmin, maxiters = integrationparams
+    @unpack solver, dt, force_dtmin, maxiters = integrationparams
+
+    # Tolerance is overridden for this `::Dθ` form.
+    # Using an identical accuracy appears to result in relatively less accurate solutions
+    # compared to the non-Dθ form.
+    tolerance = 1e-10
 
     Mtop = susceptibility(topheight, modeequation; params=params)
     Rtop, dRdθtop = bookerreflection(modeequation.ea, Mtop, Dθ())

--- a/src/modefinder.jl
+++ b/src/modefinder.jl
@@ -491,16 +491,10 @@ Find `EigenAngle`s associated with `modeequation.waveguide` within the domain of
 the GRPF algorithm searches for roots of `modeequation`. If `origcoords == nothing`,
 it is computed with [`defaultmesh`](@ref).
 
-Roots found by the GRPF algorithm are confirmed to a tolerance of approximately 3 orders
-of magnitude greater than `grpfparams.tolerance` in both the real and imaginary component.
-For example, if `grpfparams.tolerance = 1e-5`, then the value of the modal equation for each
-root must be less than `1e-2`. Typically the values of each component are close to
-`grpfparams.tolerance`.
-
-There is also a check for redundant modes that requires modes to be separated by at least
-2 orders of magnitude greater than `grpfparams.tolerance` in real and/or imaginary
+There is a check for redundant modes that requires modes to be separated by at least
+1 orders of magnitude greater than `grpfparams.tolerance` in real and/or imaginary
 component. For example, if `grpfparams.tolerance = 1e-5`, then either the real or imaginary
-component of each mode must be separated by at least 1e-3 from every other mode.
+component of each mode must be separated by at least 1e-4 from every other mode.
 """
 function findmodes(modeequation::ModeEquation, origcoords=nothing; params=LMPParams())
     @unpack approxsusceptibility, grpfparams = params

--- a/test/LongwaveModePropagator.jl
+++ b/test/LongwaveModePropagator.jl
@@ -28,7 +28,7 @@ function test_propagate(scenario)
     @test phase4 ≈ phase3    rtol=1e-3
 
     # Are params being carried through?
-    params = LMPParams(earthradius=6350e3)
+    params = LMPParams(earthradius=6300e3)
     E5, amp5, phase5 = propagate(waveguide, tx, rx; params=params)
     @test !isapprox(E5, E, rtol=1e-3)
     @test !isapprox(amp5, amp, rtol=1e-3)
@@ -59,7 +59,7 @@ function test_propagate_segmented(scenario)
     @test phase1 ≈ phase   rtol=1e-3
 
     # Are params being carried through?
-    params = LMPParams(earthradius=6350e3)
+    params = LMPParams(earthradius=6300e3)
     E3, amp3, phase3 = propagate(waveguide, tx, rx; params=params)
     @test !isapprox(E3, E, rtol=1e-3)
     @test !isapprox(amp3, amp, rtol=1e-3)

--- a/test/bookerquartic.jl
+++ b/test/bookerquartic.jl
@@ -13,13 +13,13 @@ function test_bookerquarticM(scenario)
              M[2,1]             1-q[i]^2-S²+M[2,2]  M[2,3];
              S*q[i]+M[3,1]      M[3,2]              C²+M[3,3]]
 
-        @test LMP.isroot(det(G); atol=1e-5)  # real barely fails 1e-6 for resonant_scenario
+        @test isroot(det(G); atol=1e-5)  # real barely fails 1e-6 for resonant_scenario
     end
 
     # Confirm Booker quartic is directly satisfied
     for i in eachindex(q)
         booker = B[5]*q[i]^4 + B[4]*q[i]^3 + B[3]*q[i]^2 + B[2]*q[i] + B[1]
-        @test LMP.isroot(booker; atol=1e-6)
+        @test isroot(booker; atol=1e-6)
     end
 end
 
@@ -38,7 +38,7 @@ function test_bookerquarticT(scenario)
         G = [1-q[i]^2+M[1,1]    M[1,2]              S*q[i]+M[1,3];
              M[2,1]             1-q[i]^2-S²+M[2,2]  M[2,3];
              S*q[i]+M[3,1]      M[3,2]              C²+M[3,3]]
-        @test LMP.isroot(det(G); atol=1e-6)
+        @test isroot(det(G); atol=1e-6)
     end
 
     # eigvals is >20 times slower than bookerquartic
@@ -47,7 +47,7 @@ function test_bookerquarticT(scenario)
     # Confirm Booker quartic is directly satisfied
     for i in eachindex(q)
         booker = B[5]*q[i]^4 + B[4]*q[i]^3 + B[3]*q[i]^2 + B[2]*q[i] + B[1]
-        @test LMP.isroot(booker; atol=1e-6)
+        @test isroot(booker; atol=1e-6)
     end
 end
 

--- a/test/modefinder.jl
+++ b/test/modefinder.jl
@@ -228,7 +228,7 @@ function test_modalequation_resonant(scenario)
     R = LMP.integratedreflection(me)
     Rg = LMP.fresnelreflection(ea, ground, tx.frequency)
     f = LMP.modalequation(R, Rg)
-    @test LMP.isroot(f; atol=1e-4)  # this test is a little cyclic
+    @test isroot(f; atol=1e-4)  # this test is a little cyclic
 
     @test f == LMP.solvemodalequation(me)
 
@@ -274,8 +274,8 @@ function test_findmodes(scenario)
 
     for m in modes
         f = LMP.solvemodalequation(m, modeequation; params=params)
-        LMP.isroot(f) || return f
-        @test LMP.isroot(f)
+        isroot(f) || return f
+        @test isroot(f)
     end
 
     # return modes
@@ -289,15 +289,15 @@ function test_roots(scenario)
     z = complex(x, -x)
 
     # isroot Real and Complex
-    @test LMP.isroot(x)
-    @test LMP.isroot(x; atol=1e-6) == false
-    @test LMP.isroot(z)
-    @test LMP.isroot(z; atol=1e-6) == false
+    @test isroot(x)
+    @test isroot(x; atol=1e-6) == false
+    @test isroot(z)
+    @test isroot(z; atol=1e-6) == false
 
     z2 = complex(1, 0)
     z3 = complex(0, 1)
-    @test LMP.isroot(z2) == false
-    @test LMP.isroot(z3) == false
+    @test isroot(z2) == false
+    @test isroot(z3) == false
 end
 
 # function evalroot(root, scenario)

--- a/test/modefinder.jl
+++ b/test/modefinder.jl
@@ -298,29 +298,6 @@ function test_roots(scenario)
     z3 = complex(0, 1)
     @test LMP.isroot(z2) == false
     @test LMP.isroot(z3) == false
-
-    # filterroots! setup
-    @unpack ea, tx, bfield, species, ground = scenario
-    waveguide = HomogeneousWaveguide(bfield, species, ground)
-    me = PhysicalModeEquation(tx.frequency, waveguide)
-
-    # nothing filtered
-    roots = copy(TEST_MODES[scenario])
-    @test LMP.filterroots!(roots, me) == roots
-    @test LMP.filterroots!(roots, tx.frequency, waveguide) == roots
-
-    # filter bad root
-    push!(roots, EigenAngle(complex(1.5, -0.5)))
-    @test LMP.filterroots!(roots, me) == TEST_MODES[scenario]
-    @test LMP.filterroots!(roots, tx.frequency, waveguide) == TEST_MODES[scenario]
-
-    # filter (or not) with different tolerance
-    roots2 = copy(roots)
-    roots2[1] = EigenAngle(roots2[1].θ + 0.001)
-    f = LMP.solvemodalequation(LMP.setea(roots2[1], me))
-    @test LMP.isroot(f; atol=0.5)  # NOTE: atol is for value of modal equation, not θ
-    @test LMP.filterroots!(roots2, me; atol=0.5) == roots2
-    @test LMP.filterroots!(roots2, me) == roots[2:end]
 end
 
 # function evalroot(root, scenario)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -47,3 +47,10 @@ function readlog(file)
 
     return dist, amplitude, phase
 end
+
+"""
+    isroot(x; atol=1e-2)
+
+Return `true` if `x` is approximately equal to 0 with the absolute tolerance `atol`.
+"""
+isroot(x; atol=1e-2, kws...) = isapprox(x, 0; atol=atol, kws...)

--- a/test/wavefields.jl
+++ b/test/wavefields.jl
@@ -128,7 +128,7 @@ function test_wavefieldreflection_resonant(scenario)
     # Ensure we are close to mode resonance with R
     f = LMP.modalequation(R, Rg)
 
-    @test LMP.isroot(f)
+    @test isroot(f)
 end
 
 function test_boundaryscalars(scenario)


### PR DESCRIPTION
Closes #36 

Introduces breaking changes that: 1) Increases default `LMPParams().integrationparams.tolerance` and 2) removes filtering of modes based on satisfying the mode condition (the previous filtering tolerance was regularly removing valid modes when this should be handled by RootsAndPoles.jl).