### PR TITLE
Remove `Frequency` type

### DIFF
--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -61,7 +61,6 @@ Fields
 ### Emitters
 
 ```@docs
-Frequency
 Transmitter
 Dipole
 VerticalDipole

--- a/examples/basic.jl
+++ b/examples/basic.jl
@@ -32,24 +32,6 @@ using LongwaveModePropagator: QE, ME
 # 
 # We'll begin by looking at the related types that `Emitter`s and `Sampler`s rely on.
 #
-# ### Frequencies
-#
-# Throughout the code, the electromagnetic wave frequency is required in different
-# forms: as a temporal frequency, angular frequency, or a wave number or wavelength.
-# These are always defined in vacuum.
-#
-# For consistency and convenience, LongwaveModePropagator defines a [`Frequency`](@ref)
-# struct containing fields for:
-#
-# - frequency `f` in Hertz
-# - angular frequency `ω` in radians/sec
-# - wavenumber `k` in radians/meter
-# - wavelength `λ` in meters
-#
-# These fields are automatically calculated when passed a temporal frequency.
-
-frequency = Frequency(20e3)
-
 # ### Antennas
 #
 # LongwaveModePropagator computes the far field in the waveguide produced from
@@ -113,7 +95,7 @@ rad2deg(azimuth(hd))
 # - `latitude::Float64`: transmitter geographic latitude in degrees.
 # - `longitude::Float64`: transmitter geographic longitude in degrees.
 # - `antenna::Antenna`: transmitter antenna.
-# - `frequency::Frequency`: transmit frequency.
+# - `frequency::Float64`: transmit frequency in Hertz.
 # - `power::Float64`: transmit power in Watts.
 #
 # Note that currently `latitude` and `longitude` are not used.

--- a/examples/integratedreflection.jl
+++ b/examples/integratedreflection.jl
@@ -59,7 +59,7 @@ nothing  #hide
 # We'll use a real ``\theta = 75°``.
 
 species = Species(QE, ME, z->waitprofile(z, 75, 0.32), electroncollisionfrequency)
-frequency = Frequency(24e3)
+frequency = 24e3
 bfield = BField(50e-6, π/2, 0)
 ea = EigenAngle(deg2rad(75));
 
@@ -100,7 +100,7 @@ nu = species.collisionfrequency.(zs)
 Wr = LMP.waitsparameter.(zs, (frequency,), (bfield,), (species,))
 
 altinterp = LinearInterpolation(reverse(Wr), reverse(zs))
-eqz = altinterp(frequency.ω)  # altitude where ω = ωᵣ
+eqz = altinterp(2π*frequency)  # altitude where ω = ωᵣ
 
 ne[end] = NaN  # otherwise Plots errors
 Wr[end] = NaN
@@ -111,9 +111,9 @@ p1 = plot([ne nu Wr], zs/1000;
           labels=["Nₑ (m⁻³)" "ν (s⁻¹)" "ωᵣ = ωₚ²/ν"], legend=:topleft,
           linewidth=1.5);
 
-vline!(p1, [frequency.ω]; linestyle=:dash, color="gray", label="");
+vline!(p1, [2π*frequency]; linestyle=:dash, color="gray", label="");
 hline!(p1, [eqz/1000]; linestyle=:dash, color="gray", label="");
-annotate!(p1, frequency.ω, 10, text(" ω", :left, 9));
+annotate!(p1, 2π*frequency, 10, text(" ω", :left, 9));
 annotate!(p1, 70, eqz/1000-3, text("ωᵣ = ω", :left, 9));
 
 R11 = abs.(sol(zs; idxs=1))
@@ -146,7 +146,7 @@ plot(p1, p2; layout=(1,2), size=(800, 400))
 
 function generatescenarios(N)
     eas = EigenAngle.(complex.(rand(N)*(π/2-π/6) .+ π/6, rand(N)*deg2rad(-10)))
-    frequencies = Frequency.(rand(N)*50e3 .+ 10e3)
+    frequencies = rand(N)*50e3 .+ 10e3
 
     B = rand(30e-6:5e-7:60e-6, N)
     ## avoiding within 1° from 0° dip angle

--- a/examples/interpretinghpbeta.jl
+++ b/examples/interpretinghpbeta.jl
@@ -214,7 +214,7 @@ function reflectionheight(params, hp, β)
         z->waitprofile(z, hp, β), z->collisionfrequency(z, params...))
     ωr = LMP.waitsparameter.(alt, (TX.frequency,), (BFIELD,), (species,))
     itp = LinearInterpolation(ωr, alt)
-    eqz = itp(TX.frequency.ω)
+    eqz = itp(2π*TX.frequency)
 
     return eqz
 end

--- a/examples/meshgrid.jl
+++ b/examples/meshgrid.jl
@@ -57,9 +57,9 @@ using LongwaveModePropagator: QE, ME, solvemodalequation, trianglemesh
 # We'll define four different [`PhysicalModeEquation`](@ref)'s that we'll use
 # throughout this example.
 
-lowfrequency = Frequency(10e3)
-midfrequency = Frequency(20e3)
-highfrequency = Frequency(100e3)
+lowfrequency = 10e3
+midfrequency = 20e3
+highfrequency = 100e3
 
 day = Species(QE, ME, z->waitprofile(z, 75, 0.35), electroncollisionfrequency)
 night = Species(QE, ME, z->waitprofile(z, 85, 0.9), electroncollisionfrequency)

--- a/examples/meshgrid2.jl
+++ b/examples/meshgrid2.jl
@@ -28,7 +28,7 @@ using LongwaveModePropagator: QE, ME, solvemodalequation, trianglemesh, defaultm
 # Here we define the `HomogeneousWaveguide` from the second half of the
 # `segmented_scenario` known to have the missing roots.
 
-frequency = Frequency(24e3)
+frequency = 24e3
 electrons = Species(QE, ME, z->waitprofile(z, 80, 0.45), electroncollisionfrequency)
 waveguide = HomogeneousWaveguide(BField(50e-6, π/2, 0), electrons, Ground(15, 0.001))
 me = PhysicalModeEquation(frequency, waveguide)

--- a/examples/wavefieldintegration.jl
+++ b/examples/wavefieldintegration.jl
@@ -46,7 +46,7 @@ nothing  #hide
 # This can be specified as `GROUND[8]`.
 
 ea = EigenAngle(deg2rad(40))
-frequency = Frequency(16e3)
+frequency = 16e3
 bfield = BField(50e-6, deg2rad(68), deg2rad(111))
 ground = GROUND[8]
 
@@ -299,7 +299,7 @@ plot(ex1p, ey1p, ex2p, hx2p; layout=(2,2), size=(400,600), top_margin=5mm)
 # First let's set up the new scenario.
 
 ea = EigenAngle(0)
-frequency = Frequency(202e3)
+frequency = 202e3
 bfield = BField(50e-6, deg2rad(68), deg2rad(111))
 ground = GROUND[8]
 nothing  #hide

--- a/src/EigenAngles.jl
+++ b/src/EigenAngles.jl
@@ -85,7 +85,7 @@ above 100 kHz.
 """
 function isdetached(ea::EigenAngle, frequency; params=LMPParams())
     C² = ea.cos²θ
-    k = frequency.k
+    k = wavenumber(frequency)
     @unpack earthradius, curvatureheight = params
     α = 2/earthradius
 
@@ -127,7 +127,7 @@ function attenuation(ea, frequency)
     ea = EigenAngle(ea)
     S₀ = referencetoground(ea.sinθ)
     neper2dB = 20log10(exp(1))  # 1 Np ≈ 8.685 dB
-    return -neper2dB*frequency.k*imag(S₀)*1e6
+    return -neper2dB*wavenumber(frequency)*imag(S₀)*1e6
 end
 
 """

--- a/src/EigenAngles.jl
+++ b/src/EigenAngles.jl
@@ -71,7 +71,7 @@ function Base.show(io::IO, ::MIME"text/plain", e::EigenAngle)
 end
 
 """
-    isdetached(ea::EigenAngle, frequency::Frequency; params=LMPParams())
+    isdetached(ea::EigenAngle, frequency; params=LMPParams())
 
 Return `true` if this is likely an earth detached (whispering gallery) mode according to the
 criteria in [Pappert1981] eq. 1 with the additional criteria that the frequency be
@@ -83,13 +83,13 @@ above 100 kHz.
     Ocean Systems Center, San Diego, CA, NOSC/TR-647, Jan. 1981.
     [Online]. Available: https://apps.dtic.mil/docs/citations/ADA096098.
 """
-function isdetached(ea::EigenAngle, frequency::Frequency; params=LMPParams())
-    C, C² = ea.cosθ, ea.cos²θ
-    f, k = frequency.f, frequency.k
+function isdetached(ea::EigenAngle, frequency; params=LMPParams())
+    C² = ea.cos²θ
+    k = frequency.k
     @unpack earthradius, curvatureheight = params
     α = 2/earthradius
 
-    return f > 100e3 && real(2im/3*(k/α)*(C²- α*curvatureheight)^(3/2)) > 12.4
+    return frequency > 100e3 && real(2im/3*(k/α)*(C²- α*curvatureheight)^(3/2)) > 12.4
 end
 
 """
@@ -115,15 +115,15 @@ function referencetoground(sinθ; params=LMPParams())
 end
 
 """
-    attenuation(ea, frequency::Frequency; params=LMPParams())
+    attenuation(ea, frequency)
 
-Compute attenuation of eigenangle `ea` at the ground.
+Compute attenuation of eigenangle `ea` at the ground for a wave `frequency` in Hertz.
 
 `ea` will be converted to an `EigenAngle` if needed.
 
 This function internally references `ea` to the ground.
 """
-function attenuation(ea, frequency::Frequency; params=LMPParams())
+function attenuation(ea, frequency)
     ea = EigenAngle(ea)
     S₀ = referencetoground(ea.sinθ)
     neper2dB = 20log10(exp(1))  # 1 Np ≈ 8.685 dB

--- a/src/Emitters.jl
+++ b/src/Emitters.jl
@@ -1,31 +1,8 @@
-# TODO: Custom "range" of Frequencies to form a spectrum for, e.g. lightning sferic
+# Electromagnetic transmitters and related functions
 
-"""
-    Frequency
-
-Electromagnetic wave defined by frequency `f`, but also carrying angular wave frequency `ω`,
-wavenumber `k`, and wavelength `λ`, all in SI units.
-"""
-struct Frequency
-    f::Float64
-    ω::Float64
-    k::Float64
-    λ::Float64
-end
-
-"""
-    Frequency(f)
-
-Return `Frequency` given electromagnetic wave frequency `f` in Hertz.
-"""
-function Frequency(f)
-    ω = 2π*f
-    k = ω/C0
-    λ = C0/f
-
-    Frequency(f, ω, k, λ)
-end
-Frequency(f::Frequency) = f
+wavenumber(f) = angular(f)/C0
+wavelength(f) = C0/f
+angular(f) = 2π*f
 
 ########
 
@@ -35,12 +12,6 @@ Frequency(f::Frequency) = f
 Abstract type for types that energize the waveguide with electromagnetic energy.
 """
 abstract type Emitter end
-
-function transmitterchecks(alt)
-    alt < 0 && error("Transmitter altitude cannot be negative.")
-
-    return true
-end
 
 """
     Transmitter{A<:Antenna} <: Emitter
@@ -53,7 +24,7 @@ Typical ground-based Transmitter.
 - `latitude::Float64`: transmitter geographic latitude in degrees.
 - `longitude::Float64`: transmitter geographic longitude in degrees.
 - `antenna::Antenna`: transmitter antenna.
-- `frequency::Frequency`: transmit frequency.
+- `frequency`: transmitter frequency in Hertz.
 - `power::Float64`: transmit power in Watts.
 """
 struct Transmitter{A<:Antenna} <: Emitter
@@ -61,7 +32,7 @@ struct Transmitter{A<:Antenna} <: Emitter
     latitude::Float64
     longitude::Float64
     antenna::A
-    frequency::Frequency
+    frequency::Float64
     power::Float64
 
     Transmitter{A}(n, la, lo, an, fr, po) where {A<:Antenna} = new(n, la, lo, an, fr, po)
@@ -79,7 +50,7 @@ power(t::Transmitter) = t.power
 Return a `Transmitter` with a `VerticalDipole` antenna and transmit power of 1000 W.
 """
 Transmitter(name, lat, lon, frequency) =
-    Transmitter{VerticalDipole}(name, lat, lon, VerticalDipole(), Frequency(frequency), 1000)
+    Transmitter{VerticalDipole}(name, lat, lon, VerticalDipole(), frequency, 1000)
 
 """
     Transmitter(frequency)
@@ -95,28 +66,4 @@ Transmitter(frequency) = Transmitter("", 0, 0, frequency)
 Return a `Transmitter` with zeroed geographic position.
 """
 Transmitter(antenna::A, frequency, power) where {A<:Antenna} =
-    Transmitter{A}("", 0, 0, antenna, Frequency(frequency), power)
-
-"""
-    AirborneTransmitter{A<:Antenna} <: Emitter
-
-Similar to `Transmitter` except it also contains an `altitude` field in meters.
-"""
-struct AirborneTransmitter{A<:Antenna} <: Emitter
-    name::String
-    latitude::Float64
-    longitude::Float64
-    altitude::Float64
-    antenna::A
-    frequency::Frequency
-    power::Float64
-
-    AirborneTransmitter{A}(n, la, lo, al, an, fr, po) where {A<:Antenna} =
-        transmitterchecks(al) && new(n, la, lo, al, an, fr, po)
-end
-
-altitude(t::AirborneTransmitter) = t.altitude
-frequency(t::AirborneTransmitter) = t.frequency
-azimuth(t::AirborneTransmitter) = azimuth(t.antenna)
-inclination(t::AirborneTransmitter) = inclination(t.antenna)
-power(t::AirborneTransmitter) = t.power
+    Transmitter{A}("", 0, 0, antenna, frequency, power)

--- a/src/Geophysics.jl
+++ b/src/Geophysics.jl
@@ -276,9 +276,10 @@ gyrofrequency(q, m, B) = q*B/m
 gyrofrequency(s::Species, b::BField) = gyrofrequency(s.charge, s.mass, b.B)
 
 """
-    magnetoionicparameters(z, frequency::Frequency, bfield::BField, species::Species)
+    magnetoionicparameters(z, frequency, bfield::BField, species::Species)
 
-Compute the magnetoionic parameters `X`, `Y`, and `Z` for height `z`.
+Compute the magnetoionic parameters `X`, `Y`, and `Z` for height `z` and wave `frequency` in
+Hertz.
 
 ```math
 X = N e² / (ϵ₀ m ω²)
@@ -299,9 +300,8 @@ Z = ν / ω
 [Ratcliffe1959]: J. A. Ratcliffe, "The magneto-ionic theory & its applications to the
     ionosphere," Cambridge University Press, 1959.
 """
-function magnetoionicparameters(z, frequency::Frequency, bfield::BField, species::Species)
-    m = species.mass
-    ω = frequency.ω
+function magnetoionicparameters(z, frequency, bfield::BField, species::Species)
+    ω = angular(frequency)
 
     invω = inv(ω)
     invE0ω = invω/E0
@@ -327,18 +327,18 @@ end
 end
 
 """
-    waitsparameter(z, frequency::Frequency, bfield::BField, species::Species)
+    waitsparameter(z, frequency, bfield::BField, species::Species)
 
-Compute Wait's conductivity parameter `Wr`.
+Compute Wait's conductivity parameter `Wr` for a wave of `frequency` in Hertz.
 
 ```math
 ωᵣ = Xω²/ν = ωₚ²/ν
 ```
 """
-function waitsparameter(z, frequency::Frequency, bfield::BField, species::Species)
-    X, Y, Z = magnetoionicparameters(z, frequency, bfield, species)
+function waitsparameter(z, frequency, bfield::BField, species::Species)
+    X, _, _ = magnetoionicparameters(z, frequency, bfield, species)
 
-    ω = frequency.ω
+    ω = angular(frequency)
     nu = species.collisionfrequency
 
     return X*ω^2/nu(z)

--- a/src/LongwaveModePropagator.jl
+++ b/src/LongwaveModePropagator.jl
@@ -35,7 +35,7 @@ export ExponentialInput, TableInput, BatchInput, BasicOutput, BatchOutput
 export Receiver, Sampler, GroundSampler
 
 # Emitters.jl
-export Transmitter, Dipole, VerticalDipole, HorizontalDipole, Frequency
+export Transmitter, Dipole, VerticalDipole, HorizontalDipole
 export inclination, azimuth
 
 # modefinder.jl

--- a/src/Wavefields.jl
+++ b/src/Wavefields.jl
@@ -79,7 +79,7 @@ Parameters passed to Pitteway integration of wavefields [Pitteway1965].
 - `e1_scalar::Float64`: scalar for wavefield vector 1.
 - `e2_scalar::Float64`: scalar for wavefield vector 2.
 - `ea::EigenAngle`: wavefield eigenangle.
-- `frequency::Frequency`: electromagentic wave frequency in Hz.
+- `frequency::Float64`: electromagentic wave frequency in Hertz.
 - `bfield::BField`: Earth's magnetic field in Tesla.
 - `species::S`: species in the ionosphere.
 - `params::LMPParams{T,T2,H}`: module-wide parameters.
@@ -91,7 +91,7 @@ struct WavefieldIntegrationParams{S,T,T2,H}
     e1_scalar::Float64
     e2_scalar::Float64
     ea::EigenAngle
-    frequency::Frequency
+    frequency::Float64
     bfield::BField
     species::S
     params::LMPParams{T,T2,H}
@@ -158,7 +158,7 @@ function dedz(e, p, z)
     M = susceptibility(z, frequency, bfield, species, params=params)
     T = tmatrix(ea, M)
 
-    return dedz(e, frequency.k, T)
+    return dedz(e, wavenumber(frequency), T)
 end
 
 """
@@ -344,7 +344,7 @@ savevalues(u, t, integrator) = ScaleRecord(integrator.p.z,
                                            integrator.p.e2_scalar)
 
 """
-    integratewavefields(zs, ea::EigenAngle, frequency::Frequency, bfield::BField,
+    integratewavefields(zs, ea::EigenAngle, frequency, bfield::BField,
         species; params=LMPParams())
 
 Compute wavefields vectors `e` at `zs` by downward integration over heights `zs`.
@@ -352,7 +352,7 @@ Compute wavefields vectors `e` at `zs` by downward integration over heights `zs`
 `params.wavefieldintegrationparams` is used by this function rather than
 `params.integrationparams`.
 """
-function integratewavefields(zs, ea::EigenAngle, frequency::Frequency, bfield::BField,
+function integratewavefields(zs, ea::EigenAngle, frequency, bfield::BField,
     species; params=LMPParams(), unscale=true)
     # TODO: version that updates output `e` in place
 
@@ -460,7 +460,7 @@ boundaryscalars(R, Rg, e, isotropic::Bool=false) =
 
 """
     fieldstrengths!(EH, zs, me::ModeEquation; params=LMPParams())
-    fieldstrengths!(EH, zs, ea::EigenAngle, frequency::Frequency, bfield::BField,
+    fieldstrengths!(EH, zs, ea::EigenAngle, frequency, bfield::BField,
         species, ground::Ground; params=LMPParams())
 
 Compute ``(Ex, Ey, Ez, Hx, Hy, Hz)ᵀ`` wavefields vectors as elements of `EH` by fullwave
@@ -469,7 +469,7 @@ integration at each height in `zs`.
 The wavefields are scaled to satisfy the waveguide boundary conditions, which is only valid
 at solutions of the mode equation.
 """
-function fieldstrengths!(EH, zs, ea::EigenAngle, frequency::Frequency, bfield::BField,
+function fieldstrengths!(EH, zs, ea::EigenAngle, frequency, bfield::BField,
     species, ground::Ground; params=LMPParams())
 
     @assert length(EH) == length(zs)

--- a/src/magnetoionic.jl
+++ b/src/magnetoionic.jl
@@ -46,8 +46,8 @@ correction subtracts ``2/Rₑ*(H - altitude)`` from the diagonal of ``M`` where 
 function susceptibility(altitude, frequency, bfield, species; params=LMPParams())
     @unpack earthradius, earthcurvature, curvatureheight = params
 
-    B, x, y, z = bfield.B, bfield.dcl, bfield.dcm, bfield.dcn
-    ω = frequency.ω
+    _, x, y, z = bfield.B, bfield.dcl, bfield.dcm, bfield.dcn
+    ω = angular(frequency)
 
     # Precompute constants (if multiple species)
     invω = inv(ω)

--- a/src/modesum.jl
+++ b/src/modesum.jl
@@ -65,8 +65,8 @@ factors where eigenangle `ea₀` is referenced to the ground.
 """
 function excitationfactorconstants(ea₀, R, Rg, frequency, ground; params=LMPParams())
     S², C² = ea₀.sin²θ, ea₀.cos²θ
-    k, ω = frequency.k, frequency.ω
     ϵᵣ, σ = ground.ϵᵣ, ground.σ
+    k, ω = wavenumber(frequency), angular(frequency)
 
     @unpack earthradius = params
 
@@ -212,7 +212,7 @@ See also: [`excitationfactorconstants`](@ref)
 """
 function heightgains(z, ea₀, frequency, efconstants::ExcitationFactor; params=LMPParams())
     C, C² = ea₀.cosθ, ea₀.cos²θ
-    k = frequency.k
+    k = wavenumber(frequency)
     @unpack F₁, F₂, F₃, F₄, Rg = efconstants
     @unpack earthradius, earthcurvature = params
 
@@ -395,7 +395,7 @@ function Efield(modes, waveguide::HomogeneousWaveguide, tx::Emitter, rx::Abstrac
 
     txpower = power(tx)
     frequency = tx.frequency
-    k = frequency.k
+    k = wavenumber(frequency)
 
     for ea in modes
         modeequation = PhysicalModeEquation(ea, frequency, waveguide)
@@ -410,7 +410,7 @@ function Efield(modes, waveguide::HomogeneousWaveguide, tx::Emitter, rx::Abstrac
         end
     end
 
-    Q = 0.6822408*sqrt(frequency.f*txpower)  # factor from lw_sum_modes.for
+    Q = 0.6822408*sqrt(frequency*txpower)  # factor from lw_sum_modes.for
     # Q = Z₀/(4π)*sqrt(2π*txpower/10k)*k/2  # Ferguson and Morfitt 1981 eq (21), V/m, NOT uV/m!
     # Q *= 100 # for V/m to uV/m
 
@@ -435,12 +435,12 @@ function Efield(modes, waveguide::HomogeneousWaveguide, tx::Emitter,
     rx::AbstractSampler{<:Real}; params=LMPParams())
 
     frequency = tx.frequency
-    k = frequency.k
+    k = wavenumber(frequency)
 
     txpower = power(tx)
     x = distance(rx, tx)
 
-    Q = 0.6822408*sqrt(frequency.f*txpower)
+    Q = 0.6822408*sqrt(frequency*txpower)
 
     # At transmitter (within 1 meter from it), E is complex NaN or Inf
     if x < 1
@@ -489,9 +489,9 @@ function Efield(waveguide::SegmentedWaveguide, wavefields_vec, adjwavefields_vec
     E = Vector{ComplexF64}(undef, Xlength)
 
     frequency = tx.frequency
-    k = frequency.k
+    k = wavenumber(frequency)
 
-    Q = 0.6822408*sqrt(frequency.f*tx.power)
+    Q = 0.6822408*sqrt(frequency*tx.power)
 
     # Initialize
     J = length(waveguide)

--- a/test/modefinder.jl
+++ b/test/modefinder.jl
@@ -168,7 +168,7 @@ function test_fresnelreflection(scenario)
     # PEC ground
     pec_ground = LMP.Ground(1, 1e12)
     vertical_ea = LMP.EigenAngle(π/2)
-    Rg = LMP.fresnelreflection(vertical_ea, pec_ground, Frequency(24e3))
+    Rg = LMP.fresnelreflection(vertical_ea, pec_ground, 24e3)
     @test isapprox(abs.(Rg), I; atol=1e-7)
 
     waveguide = HomogeneousWaveguide(bfield, species, ground)


### PR DESCRIPTION
Potentially **Breaking**

Just calculate angular frequency and wave number from a wave frequency argument as necessary.

This simplifies the code base and also means we aren't passing structs around when we often only need a float or a single multiplication.