### PR TITLE
Secant method to refine roots

### DIFF
--- a/src/LongwaveModePropagator.jl
+++ b/src/LongwaveModePropagator.jl
@@ -71,7 +71,7 @@ coefficient matrix in `modefinder.jl`.
 end
 export IntegrationParams
 
-const DEFAULT_GRPFPARAMS = GRPFParams(100000, 1e-5, true)
+const DEFAULT_GRPFPARAMS = GRPFParams(100000, 1e-4, true)
 
 """
     LMPParams{T,T2,H <: AbstractRange{Float64}}
@@ -86,10 +86,10 @@ Parameters for the `LongwaveModePropagator` module with defaults:
 - `curvatureheight::Float64 = 50e3`: reference height for Earth curvature in meters. At this
     height, the index of refraction is 1, and is therefore the reference height for
     eigenangles.
-- `approxsusceptibility::Bool = false`: use a cubic interpolating spline representation of
-    [`susceptibility`](@ref) during the integration of [`dRdz`](@ref).
-- `susceptibilitysplinestep::Float64 = 10.0`: altitude step in meters used to build the
-    spline representation of [`susceptibility`](@ref) if `approxsusceptibility == true`.
+- `refineeigenangles::Bool = true`: after applying GRPF to identify waveguide eigenangles,
+    refine their values using the secant method.
+- `refineeigenangles_tolerance::Float64 = 1e-10`: largest acceptable change in eigenangles
+- `refineeigenangles_maxiter::Int = 200`: maximum number of refinement iterations
 - `grpfparams::GRPFParams = GRPFParams(100000, 1e-5, true)`: parameters for the `GRPF`
     complex root-finding algorithm.
 - `integrationparams::IntegrationParams{T} =
@@ -119,8 +119,9 @@ See also: [`IntegrationParams`](@ref)
     earthradius::Float64 = 6369e3  # m
     earthcurvature::Bool = true
     curvatureheight::Float64 = 50e3  # m
-    approxsusceptibility::Bool = false
-    susceptibilitysplinestep::Float64 = 10.0
+    refineeigenangles::Bool = true
+    refineeigenangles_tolerance::Float64 = 1e-10
+    refineeigenangles_maxiter::Int = 200
     grpfparams::GRPFParams = DEFAULT_GRPFPARAMS
     integrationparams::IntegrationParams{T} = IntegrationParams()
     wavefieldheights::H = range(topheight, 0; length=513)

--- a/src/magnetoionic.jl
+++ b/src/magnetoionic.jl
@@ -111,29 +111,3 @@ susceptibility(altitude, me::ModeEquation; params=LMPParams()) =
 
 susceptibility(altitude, frequency, w::HomogeneousWaveguide; params=LMPParams()) =
     susceptibility(altitude, frequency, w.bfield, w.species; params)
-
-"""
-    susceptibilityspline(frequency, bfield, species; params=LMPParams())
-    susceptibilityspline(frequency, w::HomogeneousWaveguide; params=LMPParams())
-    susceptibilityspline(me::ModeEquation; params=LMPParams())
-
-Construct a cubic interpolating spline of [`susceptibility`](@ref) and return the callable
-`Interpolations` type.
-
-`params.susceptibilitysplinestep` is the altitude step in meters used to construct the
-spline between `BOTTOMHEIGHT` and `params.topheight`.
-"""
-function susceptibilityspline(frequency, bfield, species; params=LMPParams())
-    zs = BOTTOMHEIGHT:params.susceptibilitysplinestep:params.topheight
-    Ms = susceptibility.(zs, (frequency,), (bfield,), (species,))
-
-    itp = CubicSplineInterpolation(zs, Ms)
-
-    return itp
-end
-
-susceptibilityspline(me::ModeEquation; params=LMPParams()) =
-    susceptibilityspline(me.frequency, me.waveguide; params)
-
-susceptibilityspline(frequency, w::HomogeneousWaveguide; params=LMPParams()) =
-    susceptibilityspline(frequency, w.bfield, w.species; params)

--- a/src/modefinder.jl
+++ b/src/modefinder.jl
@@ -184,10 +184,9 @@ function dwmatrix(θ, T, dT)
 end
 
 """
-    dRdz(R, modeequation, z, susceptibilityfcn=z->susceptibility(z, modeequation; params=LMPParams()))
+    dRdz(R, modeequation, z)
 
 Compute the differential of the reflection matrix `R`, ``dR/dz``, at height `z`.
-`susceptibilityfcn` is a function returning the ionosphere susceptibility at height `z`.  
 
 Following the Budden formalism for the reflection of an (obliquely) incident plane wave from
 a horizontally stratified ionosphere [Budden1955a], the differential of the
@@ -204,12 +203,12 @@ the ionosphere as if it were a sharp boundary at the stopping level with free sp
     reflexion of long radio waves from the ionosphere,” Proc. R. Soc. Lond. A, vol. 227,
     no. 1171, pp. 516–537, Feb. 1955.
 """
-function dRdz(R, modeequation, z, susceptibilityfcn=z->susceptibility(z, modeequation; params=LMPParams()))
+function dRdz(R, modeequation, z; params=LMPParams())
     @unpack θ, frequency = modeequation
 
     k = wavenumber(frequency)
 
-    M = susceptibilityfcn(z)
+    M = susceptibility(z, modeequation; params)
     T = tmatrix(θ, M)
     W11, W21, W12, W22 = wmatrix(θ, T)
 
@@ -249,18 +248,14 @@ function dRdθdz(RdRdθ, p, z)
 end
 
 """
-    integratedreflection(modeequation::PhysicalModeEquation;
-        params=LMPParams(), susceptibilityfcn=z->susceptibility(z, modeequation; params))
+    integratedreflection(modeequation::PhysicalModeEquation; params=LMPParams())
 
 Integrate ``dR/dz`` downward through the ionosphere described by `modeequation` from
 `params.topheight`, returning the ionosphere reflection coefficient `R` at the ground.
-`susceptibilityfcn` is a function returning the ionosphere susceptibility tensor as a
-function of altitude `z` in meters.
 
 `params.integrationparams` are passed to `DifferentialEquations.jl`.
 """
-function integratedreflection(modeequation::PhysicalModeEquation;
-    params=LMPParams(), susceptibilityfcn=z->susceptibility(z, modeequation; params))::SMatrix{2,2,ComplexF64,4}
+function integratedreflection(modeequation::PhysicalModeEquation; params=LMPParams())
 
     @unpack topheight, integrationparams = params
     @unpack tolerance, solver, dt, force_dtmin, maxiters = integrationparams
@@ -268,7 +263,7 @@ function integratedreflection(modeequation::PhysicalModeEquation;
     Mtop = susceptibility(topheight, modeequation; params)
     Rtop = bookerreflection(modeequation.θ, Mtop)
 
-    prob = ODEProblem{false}((R,p,z)->dRdz(R,p,z,susceptibilityfcn), Rtop, (topheight, BOTTOMHEIGHT), modeequation)
+    prob = ODEProblem{false}((R,p,z)->dRdz(R,p,z; params), Rtop, (topheight, BOTTOMHEIGHT), modeequation)
 
     # WARNING: When save_on=false, don't try interpolating the solution!
     sol = solve(prob, solver; abstol=tolerance, reltol=tolerance,
@@ -421,19 +416,15 @@ function dmodalequation(R, dR, Rg, dRg)
 end
 
 """
-    solvemodalequation(modeequation::PhysicalModeEquation;
-        params=LMPParams(), susceptibilityfcn=z->susceptibility(z, modeequation; params))
+    solvemodalequation(modeequation::PhysicalModeEquation; params=LMPParams())
 
 Compute the ionosphere and ground reflection coefficients and return the value of the
-determinental modal equation associated with `modeequation`. `susceptibilityfcn` is a
-function that returns the ionosphere susceptibility as a function of altitude `z` in meters.
+determinental modal equation associated with `modeequation`.
 
 See also: [`solvedmodalequation`](@ref)
 """
-function solvemodalequation(modeequation::PhysicalModeEquation;
-    params=LMPParams(), susceptibilityfcn=z->susceptibility(z, modeequation; params))
-
-    R = integratedreflection(modeequation; params, susceptibilityfcn=susceptibilityfcn)
+function solvemodalequation(modeequation::PhysicalModeEquation; params=LMPParams())
+    R = integratedreflection(modeequation; params)
     Rg = fresnelreflection(modeequation)
 
     f = modalequation(R, Rg)
@@ -441,17 +432,13 @@ function solvemodalequation(modeequation::PhysicalModeEquation;
 end
 
 """
-    solvemodalequation(θ, modeequation::PhysicalModeEquation;
-        params=LMPParams(), susceptibilityfcn=z->susceptibility(z, modeequation; params))
+    solvemodalequation(θ, modeequation::PhysicalModeEquation; params=LMPParams())
 
 Set `θ` for `modeequation` and then solve the modal equation.
 """
-function solvemodalequation(θ, modeequation::PhysicalModeEquation;
-    params=LMPParams(), susceptibilityfcn=z->susceptibility(z, modeequation; params))
-
-    # Convenience function for `grpf`
+function solvemodalequation(θ, modeequation::PhysicalModeEquation; params=LMPParams())
     modeequation = setea(θ, modeequation)
-    solvemodalequation(modeequation; params, susceptibilityfcn=susceptibilityfcn)
+    solvemodalequation(modeequation; params)
 end
 
 """
@@ -497,8 +484,8 @@ There is a check for redundant modes that requires modes to be separated by at l
 component. For example, if `grpfparams.tolerance = 1e-5`, then either the real or imaginary
 component of each mode must be separated by at least 1e-4 from every other mode.
 """
-function findmodes(modeequation::ModeEquation, mesh=nothing; params=LMPParams())
-    @unpack approxsusceptibility, grpfparams = params
+function findmodes(modeequation::ModeEquation, mesh=nothing; params=LMPParams(), refine=true)
+    @unpack grpfparams = params
 
     if isnothing(mesh)
         mesh = defaultmesh(modeequation.frequency)
@@ -508,14 +495,7 @@ function findmodes(modeequation::ModeEquation, mesh=nothing; params=LMPParams())
     # is possible multiple identical modes will be identified. Checks for valid and
     # redundant modes help ensure valid eigenangles are returned from this function.
 
-    if approxsusceptibility
-        susceptibilityfcn = susceptibilityspline(modeequation; params)
-    else
-        susceptibilityfcn = z -> susceptibility(z, modeequation; params)
-    end
-
-    roots, _ = grpf(θ->solvemodalequation(θ, modeequation;
-        params, susceptibilityfcn=susceptibilityfcn), mesh, grpfparams)
+    roots, _ = grpf(θ->solvemodalequation(θ, modeequation; params), mesh, grpfparams)
 
     # Scale tolerance for filtering
     # if tolerance is 1e-8, this rounds to 7 decimal places

--- a/test/magnetoionic.jl
+++ b/test/magnetoionic.jl
@@ -27,45 +27,11 @@ function test_susceptibility(scenario)
     @inferred LMP.susceptibility(70e3, tx.frequency, bfield, species)
 end
 
-function test_spline(scenario)
-    @unpack tx, bfield, species = scenario
-
-    itp = LMP.susceptibilityspline(tx.frequency, bfield, species)
-
-    zs = LMP.BOTTOMHEIGHT:1:LMPParams().topheight
-    Ms = LMP.susceptibility.(zs, (tx.frequency,), (bfield,), (species,))
-    Mitp = itp.(zs)
-
-    function matrix(M)
-        mat = Matrix{eltype(M[1])}(undef, length(M), 9)
-        for i in eachindex(M)
-            mat[i,:] = M[i]
-        end
-        return mat
-    end
-
-    @test matrix(Mitp) ≈ matrix(Ms) rtol=1e-5
-
-    # plot(matrix(real(Ms)), zs/1000, legend=false)
-    # plot!(matrix(real(Mitp)), zs/1000, linestyle=:dash)
-
-    # Mdiff = matrix(real(Ms)) .- matrix(real(Mitp))
-    # scaleddiff = Mdiff./matrix(real(Ms))
-    # plot(Mdiff, zs/1000, legend=false, ylims=(0,110))
-
-    # Make sure `params.susceptibilitysplinestep` is being used
-    itp2 = LMP.susceptibilityspline(tx.frequency, bfield, species; params=LMPParams(susceptibilitysplinestep=10.0))
-    itp3 = LMP.susceptibilityspline(tx.frequency, bfield, species; params=LMPParams(susceptibilitysplinestep=20.0))
-    @test itp == itp2
-    @test itp != itp3
-end
-
 @testset "magnetoionic.jl" begin
     @info "Testing magnetoionic"
 
     for scn in (verticalB_scenario, resonant_scenario, nonresonant_scenario,
             multiplespecies_scenario)
         test_susceptibility(scn)
-        test_spline(scn)
     end
 end

--- a/test/modefinder.jl
+++ b/test/modefinder.jl
@@ -108,16 +108,6 @@ function test_integratedreflection_vertical(scenario)
     R = LMP.integratedreflection(me)
 
     @test R[1,2] ≈ R[2,1]
-
-    # Let's also check with interpolation susceptibilityfcn here
-    Mfcn = z -> LMP.susceptibility(z, me)
-    R2 = LMP.integratedreflection(me; susceptibilityfcn=Mfcn)
-    
-    Mfcn2 = LMP.susceptibilityspline(me)
-    R3 = LMP.integratedreflection(me; susceptibilityfcn=Mfcn2)
-    
-    @test R2 ≈ R
-    @test maxabsdiff(R, R3) < 1e-6
 end
 
 function test_integratedreflection_deriv(scenario)
@@ -205,16 +195,6 @@ function test_solvemodalequation(scenario)
     me2 = PhysicalModeEquation(0.0+0.0im, tx.frequency, waveguide)
     f2 = LMP.solvemodalequation(ea, me2)
     @test f == f2
-
-    # Test with specified susceptibilityfcn
-    Mfcn = z -> LMP.susceptibility(z, me)
-    f3 = @inferred LMP.solvemodalequation(me; susceptibilityfcn=Mfcn)
-
-    Mfcn2 = LMP.susceptibilityspline(me)
-    f4 = @inferred LMP.solvemodalequation(me; susceptibilityfcn=Mfcn2)
-
-    @test f ≈ f3
-    @test abs(f - f4) < 1e-3
 end
 
 function test_modalequation_resonant(scenario)

--- a/test/modefinder.jl
+++ b/test/modefinder.jl
@@ -243,9 +243,11 @@ function test_findmodes(scenario)
     modes = @inferred findmodes(modeequation, origcoords; params=LMPParams(refineeigenangles=false))
     modes2 = findmodes(modeequation, origcoords; params=LMPParams(refineeigenangles=true))
     modes3 = @inferred findmodes(modeequation)
+    modes4 = findmodes(modeequation)
 
+    @test modes2 ≈ modes4
+    @test modes3 ≈ modes4
     @test length(modes) == length(modes2) == length(modes3)
-    @test modes ≈ modes3 atol=1e-5
 
     fparams = LMPParams(integrationparams=IntegrationParams(tolerance=1e-8))
     for m in modes


### PR DESCRIPTION
By default, use a lower tolerance for GRPF and refine eigenangles using a secant method. Ultimately, the accuracy of the eigenangle improves by at least a couple orders of magnitude, but there is a ~30% increase in run time.